### PR TITLE
Define step definitions using regex, and support step arguments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Carthage/Checkouts/Regex"]
+	path = Carthage/Checkouts/Regex
+	url = https://github.com/sharplet/Regex.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "Quick/Quick"
+github "sharplet/Regex"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "Quick/Nimble" "v2.0.0"
-github "Quick/Quick" "v0.7.0"
+github "Quick/Nimble" "v3.0.0"
+github "Quick/Quick" "v0.8.0"
+github "sharplet/Regex" "v0.2.1"

--- a/Carthage/Checkouts/Nimble/.gitignore
+++ b/Carthage/Checkouts/Nimble/.gitignore
@@ -4,3 +4,10 @@ build/
 .idea
 DerivedData/
 Nimble.framework.zip
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build

--- a/Carthage/Checkouts/Nimble/CONTRIBUTING.md
+++ b/Carthage/Checkouts/Nimble/CONTRIBUTING.md
@@ -33,9 +33,15 @@ it.
 - Went to the kitchen, only to forget why you went in the first place?
   Better submit an issue.
 
+Be sure to include in your issue:
+
+- Your Xcode version (eg - Xcode 7.0.1 7A1001)
+- Your version of Nimble (eg - v2.0.0 or git sha `20a3f3b4e63cc8d97c92c4164bf36f2a2c9a6e1b`)
+- What are the steps to reproduce this issue?
+
 ## Building the Project
 
-- Use `Nimble.xcproj` to work on Nimble.
+- Use `Nimble.xcodeproj` to work on Nimble.
 
 ## Pull Requests
 
@@ -51,10 +57,8 @@ it.
   tests using `./test`.
 - If you've added a file to the project, make sure it's included in both
   the OS X and iOS targets.
-- To make minor updates to old versions of Nimble that support Swift
-  1.1, issue a pull request against the `swift-1.1` branch. The master
-  branch supports Swift 1.2. Travis CI will only pass for pull requests
-  issued against the `swift-1.1` branch.
+- The `master` branch will always support the stable Xcode version. Other
+  branches will point to their corresponding versions they support.
 - If you're making a configuration change, make sure to edit both the xcode
   project and the podspec file.
 
@@ -95,7 +99,7 @@ some "ground rules":
 
 The process is relatively straight forward, but here's is a useful checklist for tagging:
 
-- Look a changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
+- Look at changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
 - Run the release script: `./script/release A.B.C release-notes-file`
 - Go to [github releases](https://github.com/Quick/Nimble/releases) and mark the tagged commit as a release.
   - Use the same release notes you created for the tag, but tweak up formatting for github.

--- a/Carthage/Checkouts/Nimble/Nimble.podspec
+++ b/Carthage/Checkouts/Nimble/Nimble.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Nimble"
-  s.version      = "2.0.0"
+  s.version      = "3.0.0"
   s.summary      = "A Matcher Framework for Swift and Objective-C"
   s.description  = <<-DESC
                    Use Nimble to express the expected outcomes of Swift or Objective-C expressions. Inspired by Cedar.
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.author       = "Quick Contributors"
   s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.9"
+  s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/Quick/Nimble.git", :tag => "v#{s.version}" }
 
   s.source_files = "Nimble", "Nimble/**/*.{swift,h,m}"

--- a/Carthage/Checkouts/Nimble/Nimble.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Nimble/Nimble.xcodeproj/project.pbxproj
@@ -66,6 +66,76 @@
 		1F4A569E1A3B3565009E1637 /* ObjCMatchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */; };
 		1F4A56A01A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */; };
 		1F4A56A11A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */; };
+		1F5DF15F1BDCA0CE00C3A531 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */; };
+		1F5DF16C1BDCA0F500C3A531 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD051968AB07008ED995 /* AssertionRecorder.swift */; };
+		1F5DF16D1BDCA0F500C3A531 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD061968AB07008ED995 /* AdapterProtocols.swift */; };
+		1F5DF16E1BDCA0F500C3A531 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD071968AB07008ED995 /* NimbleXCTestHandler.swift */; };
+		1F5DF16F1BDCA0F500C3A531 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
+		1F5DF1701BDCA0F500C3A531 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD081968AB07008ED995 /* DSL.swift */; };
+		1F5DF1711BDCA0F500C3A531 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
+		1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD091968AB07008ED995 /* Expectation.swift */; };
+		1F5DF1731BDCA0F500C3A531 /* ObjCExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0FEA991AF32DA4001E554E /* ObjCExpectation.swift */; };
+		1F5DF1741BDCA0F500C3A531 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0A1968AB07008ED995 /* Expression.swift */; };
+		1F5DF1751BDCA0F500C3A531 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0B1968AB07008ED995 /* FailureMessage.swift */; };
+		1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB1BC781A92235600F743C3 /* AllPass.swift */; };
+		1F5DF1771BDCA0F500C3A531 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0E1968AB07008ED995 /* BeAKindOf.swift */; };
+		1F5DF1781BDCA0F500C3A531 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0D1968AB07008ED995 /* BeAnInstanceOf.swift */; };
+		1F5DF1791BDCA0F500C3A531 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0F1968AB07008ED995 /* BeCloseTo.swift */; };
+		1F5DF17A1BDCA0F500C3A531 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD101968AB07008ED995 /* BeEmpty.swift */; };
+		1F5DF17B1BDCA0F500C3A531 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD111968AB07008ED995 /* BeginWith.swift */; };
+		1F5DF17C1BDCA0F500C3A531 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD121968AB07008ED995 /* BeGreaterThan.swift */; };
+		1F5DF17D1BDCA0F500C3A531 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD131968AB07008ED995 /* BeGreaterThanOrEqualTo.swift */; };
+		1F5DF17E1BDCA0F500C3A531 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD141968AB07008ED995 /* BeIdenticalTo.swift */; };
+		1F5DF17F1BDCA0F500C3A531 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD151968AB07008ED995 /* BeLessThan.swift */; };
+		1F5DF1801BDCA0F500C3A531 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD161968AB07008ED995 /* BeLessThanOrEqual.swift */; };
+		1F5DF1811BDCA0F500C3A531 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD171968AB07008ED995 /* BeLogical.swift */; };
+		1F5DF1821BDCA0F500C3A531 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD181968AB07008ED995 /* BeNil.swift */; };
+		1F5DF1831BDCA0F500C3A531 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1A1968AB07008ED995 /* Contain.swift */; };
+		1F5DF1841BDCA0F500C3A531 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1B1968AB07008ED995 /* EndWith.swift */; };
+		1F5DF1851BDCA0F500C3A531 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
+		1F5DF1861BDCA0F500C3A531 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
+		1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EC19FE43C200E9D9FE /* Match.swift */; };
+		1F5DF1881BDCA0F500C3A531 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
+		1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
+		1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
+		1F5DF18B1BDCA0F500C3A531 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD251968AB07008ED995 /* Functional.swift */; };
+		1F5DF18C1BDCA0F500C3A531 /* Poll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Poll.swift */; };
+		1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD271968AB07008ED995 /* SourceLocation.swift */; };
+		1F5DF18E1BDCA0F500C3A531 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD281968AB07008ED995 /* Stringers.swift */; };
+		1F5DF18F1BDCA0F500C3A531 /* AsyncMatcherWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2A1968AB07008ED995 /* AsyncMatcherWrapper.swift */; };
+		1F5DF1901BDCA0F500C3A531 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */; };
+		1F5DF1911BDCA0F500C3A531 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
+		1F5DF1921BDCA10200C3A531 /* AsynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE5195C121200ED456B /* AsynchronousTest.swift */; };
+		1F5DF1931BDCA10200C3A531 /* SynchronousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648D31963AAB2001F9C46 /* SynchronousTests.swift */; };
+		1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
+		1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14FB63194180C5009F2A08 /* utils.swift */; };
+		1F5DF1961BDCA10200C3A531 /* ObjectWithLazyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648CB19639F5A001F9C46 /* ObjectWithLazyProperty.swift */; };
+		1F5DF1971BDCA10200C3A531 /* AllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD72EC631A93874A002F7651 /* AllPassTest.swift */; };
+		1F5DF1981BDCA10200C3A531 /* BeAKindOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B5AD31963E13900CA8BF9 /* BeAKindOfTest.swift */; };
+		1F5DF1991BDCA10200C3A531 /* BeAnInstanceOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */; };
+		1F5DF19A1BDCA10200C3A531 /* BeCloseToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EF5195C147800ED456B /* BeCloseToTest.swift */; };
+		1F5DF19B1BDCA10200C3A531 /* BeEmptyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F299EAA19627B2D002641AF /* BeEmptyTest.swift */; };
+		1F5DF19C1BDCA10200C3A531 /* BeginWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EFB195C186800ED456B /* BeginWithTest.swift */; };
+		1F5DF19D1BDCA10200C3A531 /* BeGreaterThanOrEqualToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F10195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift */; };
+		1F5DF19E1BDCA10200C3A531 /* BeGreaterThanTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F07195C18CF00ED456B /* BeGreaterThanTest.swift */; };
+		1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */; };
+		1F5DF1A01BDCA10200C3A531 /* BeIdenticalToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB90097195EC4B8001D7FAE /* BeIdenticalToTest.swift */; };
+		1F5DF1A11BDCA10200C3A531 /* BeLessThanOrEqualToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F0D195C18F500ED456B /* BeLessThanOrEqualToTest.swift */; };
+		1F5DF1A21BDCA10200C3A531 /* BeLessThanTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F0A195C18E100ED456B /* BeLessThanTest.swift */; };
+		1F5DF1A31BDCA10200C3A531 /* BeLogicalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EEE195C136500ED456B /* BeLogicalTest.swift */; };
+		1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EF8195C175000ED456B /* BeNilTest.swift */; };
+		1F5DF1A51BDCA10200C3A531 /* ContainTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F01195C189500ED456B /* ContainTest.swift */; };
+		1F5DF1A61BDCA10200C3A531 /* EndWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EFE195C187600ED456B /* EndWithTest.swift */; };
+		1F5DF1A71BDCA10200C3A531 /* EqualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F04195C18B700ED456B /* EqualTest.swift */; };
+		1F5DF1A81BDCA10200C3A531 /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
+		1F5DF1A91BDCA10200C3A531 /* MatchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EF19FE442800E9D9FE /* MatchTest.swift */; };
+		1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */; };
+		1F5DF1AB1BDCA10200C3A531 /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
+		1F5DF1AC1BDCA16E00C3A531 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD211968AB07008ED995 /* DSL.m */; };
+		1F5DF1AD1BDCA16E00C3A531 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD231968AB07008ED995 /* NMBExceptionCapture.m */; };
+		1F5DF1AE1BDCA17600C3A531 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1A742E1940169200FFFC47 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F5DF1AF1BDCA17600C3A531 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD8CD201968AB07008ED995 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F5DF1B01BDCA17600C3A531 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD8CD221968AB07008ED995 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F8A37B01B7C5042001C8357 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
 		1F8A37B11B7C5042001C8357 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
 		1F925EB8195C0D6300ED456B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F925EAD195C0D6300ED456B /* Nimble.framework */; };
@@ -173,12 +243,12 @@
 		29EA59641B551ED2002D767E /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
 		29EA59661B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
 		29EA59671B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
-		472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; settings = {ASSET_TAGS = (); }; };
+		472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD1391B9E0A9700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD13A1B9E0A9F00C7B8DA /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
 		472FD13B1B9E0CFE00C7B8DA /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
-		4793854D1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; settings = {ASSET_TAGS = (); }; };
-		4793854E1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; settings = {ASSET_TAGS = (); }; };
+		4793854D1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; };
+		4793854E1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; };
 		965B0D091B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0A1B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0C1B62C06D0005AE66 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
@@ -206,6 +276,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1F1A74281940169200FFFC47;
 			remoteInfo = "Nimble-iOS";
+		};
+		1F5DF1601BDCA0CE00C3A531 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1F1A74201940169200FFFC47 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F5DF1541BDCA0CE00C3A531;
+			remoteInfo = "Nimble-tvOS";
 		};
 		1F6BB82A1968BFF9009F1DBB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -292,6 +369,8 @@
 		1F4A56991A3B3539009E1637 /* ObjCEqualTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCEqualTest.m; sourceTree = "<group>"; };
 		1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCMatchTest.m; sourceTree = "<group>"; };
 		1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCRaiseExceptionTest.m; sourceTree = "<group>"; };
+		1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F5DF15E1BDCA0CE00C3A531 /* NimbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSyncTest.m; sourceTree = "<group>"; };
 		1F925EAD195C0D6300ED456B /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F925EB7195C0D6300ED456B /* NimbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -381,6 +460,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1F5DF1511BDCA0CE00C3A531 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF15B1BDCA0CE00C3A531 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF15F1BDCA0CE00C3A531 /* Nimble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F925EA9195C0D6300ED456B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -425,6 +519,8 @@
 				1F1A74341940169200FFFC47 /* NimbleTests.xctest */,
 				1F925EAD195C0D6300ED456B /* Nimble.framework */,
 				1F925EB7195C0D6300ED456B /* NimbleTests.xctest */,
+				1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */,
+				1F5DF15E1BDCA0CE00C3A531 /* NimbleTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -609,7 +705,6 @@
 				1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */,
 				965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */,
 				DDEFAEB31A93CBE6005CA37A /* ObjCAllPassTest.m */,
-				30FC9B081B7E48670097E2D6 /* ObjCSyncTest.m */,
 			);
 			path = objc;
 			sourceTree = "<group>";
@@ -624,6 +719,16 @@
 				1FD8CD601968AB07008ED995 /* DSL.h in Headers */,
 				1FD8CD641968AB07008ED995 /* NMBExceptionCapture.h in Headers */,
 				1F1A742F1940169200FFFC47 /* Nimble.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF1521BDCA0CE00C3A531 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF1AF1BDCA17600C3A531 /* DSL.h in Headers */,
+				1F5DF1B01BDCA17600C3A531 /* NMBExceptionCapture.h in Headers */,
+				1F5DF1AE1BDCA17600C3A531 /* Nimble.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -679,6 +784,42 @@
 			productReference = 1F1A74341940169200FFFC47 /* NimbleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		1F5DF1541BDCA0CE00C3A531 /* Nimble-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F5DF16A1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOS" */;
+			buildPhases = (
+				1F5DF1501BDCA0CE00C3A531 /* Sources */,
+				1F5DF1511BDCA0CE00C3A531 /* Frameworks */,
+				1F5DF1521BDCA0CE00C3A531 /* Headers */,
+				1F5DF1531BDCA0CE00C3A531 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Nimble-tvOS";
+			productName = "Nimble-tvOS";
+			productReference = 1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F5DF15D1BDCA0CE00C3A531 /* Nimble-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F5DF16B1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOSTests" */;
+			buildPhases = (
+				1F5DF15A1BDCA0CE00C3A531 /* Sources */,
+				1F5DF15B1BDCA0CE00C3A531 /* Frameworks */,
+				1F5DF15C1BDCA0CE00C3A531 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1F5DF1611BDCA0CE00C3A531 /* PBXTargetDependency */,
+			);
+			name = "Nimble-tvOSTests";
+			productName = "Nimble-tvOSTests";
+			productReference = 1F5DF15E1BDCA0CE00C3A531 /* NimbleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		1F925EAC195C0D6300ED456B /* Nimble-OSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1F925EC0195C0D6300ED456B /* Build configuration list for PBXNativeTarget "Nimble-OSX" */;
@@ -724,8 +865,8 @@
 		1F1A74201940169200FFFC47 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Jeff Hui";
 				TargetAttributes = {
 					1F1A74281940169200FFFC47 = {
@@ -734,6 +875,12 @@
 					1F1A74331940169200FFFC47 = {
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = 1F1A74281940169200FFFC47;
+					};
+					1F5DF1541BDCA0CE00C3A531 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+					1F5DF15D1BDCA0CE00C3A531 = {
+						CreatedOnToolsVersion = 7.1;
 					};
 					1F925EAC195C0D6300ED456B = {
 						CreatedOnToolsVersion = 6.0;
@@ -760,6 +907,8 @@
 				1F1A74331940169200FFFC47 /* Nimble-iOSTests */,
 				1F925EAC195C0D6300ED456B /* Nimble-OSX */,
 				1F925EB6195C0D6300ED456B /* Nimble-OSXTests */,
+				1F5DF1541BDCA0CE00C3A531 /* Nimble-tvOS */,
+				1F5DF15D1BDCA0CE00C3A531 /* Nimble-tvOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -773,6 +922,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1F1A74321940169200FFFC47 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF1531BDCA0CE00C3A531 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF15C1BDCA0CE00C3A531 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -867,7 +1030,6 @@
 				1F925F0B195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FB1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
 				1FB90098195EC4B8001D7FAE /* BeIdenticalToTest.swift in Sources */,
-				30FC9B091B7E48670097E2D6 /* ObjCSyncTest.m in Sources */,
 				1F4A56761A3B3253009E1637 /* ObjCBeGreaterThanTest.m in Sources */,
 				1F925EF9195C175000ED456B /* BeNilTest.swift in Sources */,
 				1F4A56701A3B319F009E1637 /* ObjCBeCloseToTest.m in Sources */,
@@ -899,6 +1061,86 @@
 				29EA59631B551ED2002D767E /* ThrowErrorTest.swift in Sources */,
 				1F4A566A1A3B3108009E1637 /* ObjCBeAnInstanceOfTest.m in Sources */,
 				472FD13B1B9E0CFE00C7B8DA /* HaveCountTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF1501BDCA0CE00C3A531 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF1791BDCA0F500C3A531 /* BeCloseTo.swift in Sources */,
+				1F5DF16C1BDCA0F500C3A531 /* AssertionRecorder.swift in Sources */,
+				1F5DF1881BDCA0F500C3A531 /* MatcherProtocols.swift in Sources */,
+				1F5DF16E1BDCA0F500C3A531 /* NimbleXCTestHandler.swift in Sources */,
+				1F5DF1751BDCA0F500C3A531 /* FailureMessage.swift in Sources */,
+				1F5DF1801BDCA0F500C3A531 /* BeLessThanOrEqual.swift in Sources */,
+				1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */,
+				1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */,
+				1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */,
+				1F5DF1861BDCA0F500C3A531 /* HaveCount.swift in Sources */,
+				1F5DF1811BDCA0F500C3A531 /* BeLogical.swift in Sources */,
+				1F5DF1741BDCA0F500C3A531 /* Expression.swift in Sources */,
+				1F5DF1911BDCA0F500C3A531 /* ObjCMatcher.swift in Sources */,
+				1F5DF1781BDCA0F500C3A531 /* BeAnInstanceOf.swift in Sources */,
+				1F5DF1771BDCA0F500C3A531 /* BeAKindOf.swift in Sources */,
+				1F5DF17F1BDCA0F500C3A531 /* BeLessThan.swift in Sources */,
+				1F5DF17C1BDCA0F500C3A531 /* BeGreaterThan.swift in Sources */,
+				1F5DF1831BDCA0F500C3A531 /* Contain.swift in Sources */,
+				1F5DF1731BDCA0F500C3A531 /* ObjCExpectation.swift in Sources */,
+				1F5DF1851BDCA0F500C3A531 /* Equal.swift in Sources */,
+				1F5DF18F1BDCA0F500C3A531 /* AsyncMatcherWrapper.swift in Sources */,
+				1F5DF1711BDCA0F500C3A531 /* DSL+Wait.swift in Sources */,
+				1F5DF17D1BDCA0F500C3A531 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				1F5DF18E1BDCA0F500C3A531 /* Stringers.swift in Sources */,
+				1F5DF1AD1BDCA16E00C3A531 /* NMBExceptionCapture.m in Sources */,
+				1F5DF16D1BDCA0F500C3A531 /* AdapterProtocols.swift in Sources */,
+				1F5DF17B1BDCA0F500C3A531 /* BeginWith.swift in Sources */,
+				1F5DF17E1BDCA0F500C3A531 /* BeIdenticalTo.swift in Sources */,
+				1F5DF17A1BDCA0F500C3A531 /* BeEmpty.swift in Sources */,
+				1F5DF18C1BDCA0F500C3A531 /* Poll.swift in Sources */,
+				1F5DF1821BDCA0F500C3A531 /* BeNil.swift in Sources */,
+				1F5DF1AC1BDCA16E00C3A531 /* DSL.m in Sources */,
+				1F5DF16F1BDCA0F500C3A531 /* AssertionDispatcher.swift in Sources */,
+				1F5DF1841BDCA0F500C3A531 /* EndWith.swift in Sources */,
+				1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */,
+				1F5DF1701BDCA0F500C3A531 /* DSL.swift in Sources */,
+				1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */,
+				1F5DF18B1BDCA0F500C3A531 /* Functional.swift in Sources */,
+				1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */,
+				1F5DF1901BDCA0F500C3A531 /* MatcherFunc.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF15A1BDCA0CE00C3A531 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF1A31BDCA10200C3A531 /* BeLogicalTest.swift in Sources */,
+				1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */,
+				1F5DF1981BDCA10200C3A531 /* BeAKindOfTest.swift in Sources */,
+				1F5DF19B1BDCA10200C3A531 /* BeEmptyTest.swift in Sources */,
+				1F5DF1A11BDCA10200C3A531 /* BeLessThanOrEqualToTest.swift in Sources */,
+				1F5DF1961BDCA10200C3A531 /* ObjectWithLazyProperty.swift in Sources */,
+				1F5DF1AB1BDCA10200C3A531 /* ThrowErrorTest.swift in Sources */,
+				1F5DF1A51BDCA10200C3A531 /* ContainTest.swift in Sources */,
+				1F5DF19E1BDCA10200C3A531 /* BeGreaterThanTest.swift in Sources */,
+				1F5DF1A21BDCA10200C3A531 /* BeLessThanTest.swift in Sources */,
+				1F5DF1921BDCA10200C3A531 /* AsynchronousTest.swift in Sources */,
+				1F5DF1A91BDCA10200C3A531 /* MatchTest.swift in Sources */,
+				1F5DF1A81BDCA10200C3A531 /* HaveCountTest.swift in Sources */,
+				1F5DF1971BDCA10200C3A531 /* AllPassTest.swift in Sources */,
+				1F5DF19C1BDCA10200C3A531 /* BeginWithTest.swift in Sources */,
+				1F5DF1A01BDCA10200C3A531 /* BeIdenticalToTest.swift in Sources */,
+				1F5DF19A1BDCA10200C3A531 /* BeCloseToTest.swift in Sources */,
+				1F5DF1A61BDCA10200C3A531 /* EndWithTest.swift in Sources */,
+				1F5DF1A71BDCA10200C3A531 /* EqualTest.swift in Sources */,
+				1F5DF1931BDCA10200C3A531 /* SynchronousTests.swift in Sources */,
+				1F5DF19D1BDCA10200C3A531 /* BeGreaterThanOrEqualToTest.swift in Sources */,
+				1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */,
+				1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */,
+				1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */,
+				1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */,
+				1F5DF1991BDCA10200C3A531 /* BeAnInstanceOfTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -973,7 +1215,6 @@
 				1F925F0C195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FC1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
 				1FB90099195EC4B8001D7FAE /* BeIdenticalToTest.swift in Sources */,
-				30FC9B0A1B7E48670097E2D6 /* ObjCSyncTest.m in Sources */,
 				1F4A56771A3B3253009E1637 /* ObjCBeGreaterThanTest.m in Sources */,
 				1F925EFA195C175000ED456B /* BeNilTest.swift in Sources */,
 				1F4A56711A3B319F009E1637 /* ObjCBeCloseToTest.m in Sources */,
@@ -1015,6 +1256,11 @@
 			isa = PBXTargetDependency;
 			target = 1F1A74281940169200FFFC47 /* Nimble-iOS */;
 			targetProxy = 1F1A74361940169200FFFC47 /* PBXContainerItemProxy */;
+		};
+		1F5DF1611BDCA0CE00C3A531 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F5DF1541BDCA0CE00C3A531 /* Nimble-tvOS */;
+			targetProxy = 1F5DF1601BDCA0CE00C3A531 /* PBXContainerItemProxy */;
 		};
 		1F6BB82B1968BFF9009F1DBB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1075,8 +1321,8 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1123,7 +1369,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1151,6 +1396,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -1166,10 +1412,11 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1183,6 +1430,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -1197,10 +1445,11 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 			};
 			name = Release;
@@ -1220,6 +1469,7 @@
 				INFOPLIST_FILE = NimbleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/NimbleTests-Bridging-Header.h";
@@ -1238,9 +1488,114 @@
 				INFOPLIST_FILE = NimbleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/NimbleTests-Bridging-Header.h";
+			};
+			name = Release;
+		};
+		1F5DF1661BDCA0CE00C3A531 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Nimble/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					XCTest,
+					"-weak-lswiftXCTest",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_MODULE_NAME = Nimble;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F5DF1671BDCA0CE00C3A531 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Nimble/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					XCTest,
+					"-weak-lswiftXCTest",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_MODULE_NAME = Nimble;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		1F5DF1681BDCA0CE00C3A531 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = NimbleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = NimbleTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F5DF1691BDCA0CE00C3A531 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = NimbleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = NimbleTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -1272,6 +1627,7 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
@@ -1306,6 +1662,7 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
@@ -1332,6 +1689,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/Nimble-OSXTests-Bridging-Header.h";
@@ -1353,6 +1711,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/Nimble-OSXTests-Bridging-Header.h";
@@ -1385,6 +1744,24 @@
 			buildConfigurations = (
 				1F1A74431940169200FFFC47 /* Debug */,
 				1F1A74441940169200FFFC47 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F5DF16A1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F5DF1661BDCA0CE00C3A531 /* Debug */,
+				1F5DF1671BDCA0CE00C3A531 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F5DF16B1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F5DF1681BDCA0CE00C3A531 /* Debug */,
+				1F5DF1691BDCA0CE00C3A531 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Carthage/Checkouts/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-OSX.xcscheme
+++ b/Carthage/Checkouts/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -43,11 +43,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugXPCServices = "NO"
@@ -66,10 +66,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/Carthage/Checkouts/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
+++ b/Carthage/Checkouts/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0710"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F1A74281940169200FFFC47"
+               BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
                BuildableName = "Nimble.framework"
-               BlueprintName = "Nimble-iOS"
+               BlueprintName = "Nimble-tvOS"
                ReferencedContainer = "container:Nimble.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,33 +32,41 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F1A74331940169200FFFC47"
+               BlueprintIdentifier = "1F5DF15D1BDCA0CE00C3A531"
                BuildableName = "NimbleTests.xctest"
-               BlueprintName = "Nimble-iOSTests"
+               BlueprintName = "Nimble-tvOSTests"
                ReferencedContainer = "container:Nimble.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
+            BuildableName = "Nimble.framework"
+            BlueprintName = "Nimble-tvOS"
+            ReferencedContainer = "container:Nimble.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      debugXPCServices = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1F1A74281940169200FFFC47"
+            BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
             BuildableName = "Nimble.framework"
-            BlueprintName = "Nimble-iOS"
+            BlueprintName = "Nimble-tvOS"
             ReferencedContainer = "container:Nimble.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -71,6 +79,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
+            BuildableName = "Nimble.framework"
+            BlueprintName = "Nimble-tvOS"
+            ReferencedContainer = "container:Nimble.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Carthage/Checkouts/Nimble/Nimble/DSL+Wait.swift
+++ b/Carthage/Checkouts/Nimble/Nimble/DSL+Wait.swift
@@ -38,15 +38,6 @@ internal class NMBWait: NSObject {
 /// Wait asynchronously until the done closure is called.
 ///
 /// This will advance the run loop.
-public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: ((Any?...) -> Void) -> Void) -> Void {
-    NMBWait.until(timeout: timeout, file: file, line: line, action: bridgeToVoidAction(action))
-}
-
-/// This bridging function should not be required in Swift 2.1 as it supports function covariance
-private func bridgeToVoidAction(vargAction: ((Any?...) -> Void) -> Void) -> ((() -> Void) -> Void) {
-    return { voidDone in
-        vargAction() { _ in
-            voidDone()
-        }
-    }
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }

--- a/Carthage/Checkouts/Nimble/Nimble/Info.plist
+++ b/Carthage/Checkouts/Nimble/Nimble/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.jeffhui.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -20,9 +20,9 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014 Jeff Hui. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Carthage/Checkouts/Nimble/Nimble/Matchers/HaveCount.swift
+++ b/Carthage/Checkouts/Nimble/Nimble/Matchers/HaveCount.swift
@@ -5,9 +5,9 @@ import Foundation
 public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(actualValue.count)"
+            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
             let result = expectedValue == actualValue.count
-            failureMessage.actualValue = "\(expectedValue)"
+            failureMessage.actualValue = "\(actualValue.count)"
             return result
         } else {
             return false
@@ -20,9 +20,9 @@ public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> Non
 public func haveCount(expectedValue: Int) -> MatcherFunc<NMBCollection> {
     return MatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(actualValue.count)"
+            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
             let result = expectedValue == actualValue.count
-            failureMessage.actualValue = "\(expectedValue)"
+            failureMessage.actualValue = "\(actualValue.count)"
             return result
         } else {
             return false

--- a/Carthage/Checkouts/Nimble/Nimble/Nimble.h
+++ b/Carthage/Checkouts/Nimble/Nimble/Nimble.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
-#import <Nimble/NMBExceptionCapture.h>
-#import <Nimble/DSL.h>
+#import "NMBExceptionCapture.h"
+#import "DSL.h"
 
 FOUNDATION_EXPORT double NimbleVersionNumber;
 FOUNDATION_EXPORT const unsigned char NimbleVersionString[];

--- a/Carthage/Checkouts/Nimble/NimbleTests/AsynchronousTest.swift
+++ b/Carthage/Checkouts/Nimble/NimbleTests/AsynchronousTest.swift
@@ -81,10 +81,4 @@ class AsyncTest: XCTestCase {
         // "clear" runloop to ensure this test doesn't poison other tests
         NSRunLoop.mainRunLoop().runUntilDate(NSDate().dateByAddingTimeInterval(2.0))
     }
-    
-    func testWaitUntilTakesAnyArguments() {
-        waitUntil { done in
-            done(nil, 0, "", NSNumber.self, {})
-        }
-    }
 }

--- a/Carthage/Checkouts/Nimble/NimbleTests/Info.plist
+++ b/Carthage/Checkouts/Nimble/NimbleTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.jeffhui.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Carthage/Checkouts/Nimble/NimbleTests/Matchers/HaveCountTest.swift
+++ b/Carthage/Checkouts/Nimble/NimbleTests/Matchers/HaveCountTest.swift
@@ -6,7 +6,7 @@ class HaveCountTest: XCTestCase {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [1, 2, 3] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [1, 2, 3] with count 1, got 3") {
             expect([1, 2, 3]).to(haveCount(1))
         }
 
@@ -19,7 +19,7 @@ class HaveCountTest: XCTestCase {
         expect(["1":1, "2":2, "3":3]).to(haveCount(3))
         expect(["1":1, "2":2, "3":3]).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 1, got 3") {
             expect(["1":1, "2":2, "3":3]).to(haveCount(1))
         }
 
@@ -32,7 +32,7 @@ class HaveCountTest: XCTestCase {
         expect(Set([1, 2, 3])).to(haveCount(3))
         expect(Set([1, 2, 3])).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [2, 3, 1] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [2, 3, 1] with count 1, got 3") {
             expect(Set([1, 2, 3])).to(haveCount(1))
         }
 

--- a/Carthage/Checkouts/Nimble/NimbleTests/objc/ObjCHaveCount.m
+++ b/Carthage/Checkouts/Nimble/NimbleTests/objc/ObjCHaveCount.m
@@ -14,7 +14,7 @@
     expect(@[]).to(haveCount(@0));
     expect(@[@1]).notTo(haveCount(@0));
 
-    expectFailureMessage(@"expected to have (1,2,3) with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have (1,2,3) with count 1, got 3", ^{
         expect(@[@1, @2, @3]).to(haveCount(@1));
     });
 
@@ -28,7 +28,7 @@
     expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@3));
     expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have {1 = 1;2 = 2;3 = 3;} with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have {1 = 1;2 = 2;3 = 3;} with count 1, got 3", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@1));
     });
 
@@ -46,7 +46,7 @@
     expect(table).to(haveCount(@3));
     expect(table).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3", ^{
         expect(table).to(haveCount(@1));
     });
 
@@ -61,7 +61,7 @@
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have {(3,1,2)} with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have {(3,1,2)} with count 1, got 3", ^{
         expect(set).to(haveCount(@1));
     });
 

--- a/Carthage/Checkouts/Nimble/README.md
+++ b/Carthage/Checkouts/Nimble/README.md
@@ -475,10 +475,6 @@ expect(actual).to(beIdenticalTo(expected));
 expect(actual).toNot(beIdenticalTo(expected));
 ```
 
-> `beIdenticalTo` only supports Objective-C objects: subclasses
-  of `NSObject`, or Swift objects bridged to Objective-C with the
-  `@objc` prefix.
-
 ## Comparisons
 
 ```swift

--- a/Carthage/Checkouts/Nimble/script/release
+++ b/Carthage/Checkouts/Nimble/script/release
@@ -13,6 +13,7 @@ function help {
     echo
     echo "VERSION should be the version to release, should not include the 'v' prefix"
     echo "RELEASE_NOTES should be a file that lists all the release notes for this version"
+    echo "              if file does not exist, creates a git-style commit with a diff as a comment"
     echo
     echo "FLAGS"
     echo "  -f  Forces override of tag"
@@ -79,9 +80,9 @@ fi
 if [ ! -f "$RELEASE_NOTES" ]; then
     echo " > Failed to find $RELEASE_NOTES. Prompting editor"
     RELEASE_NOTES=.release-changes
-    LATEST_TAG=`git for-each-ref refs/tags --sort=-refname --format="%(refname:short)" | grep 'v\\?\\d\\+\\.\\d\\+\\.\\d\\+' | ruby -e 'puts STDIN.read.split("\n").sort { |a,b| a.gsub("v", "").split(".").map(&:to_i) <=> b.gsub("v", "").split(".").map(&:to_i) }.last'`
+    LATEST_TAG=`git for-each-ref refs/tags --sort=-refname --format="%(refname:short)" | grep -E "^v\d+\.\d+\.\d+(-\w+(\.\d)?)?\$" | ruby -e 'puts STDIN.read.split("\n").sort { |a,b| Gem::Version.new(a.gsub(/^v/, "")) <=> Gem::Version.new(b.gsub(/^v/, "")) }.last'`
     echo " > Latest tag ${LATEST_TAG}"
-    echo "Nimble v$VERSION" > $RELEASE_NOTES
+    echo "${POD_NAME} v$VERSION" > $RELEASE_NOTES
     echo "================" >> $RELEASE_NOTES
     echo >> $RELEASE_NOTES
     echo "# Changelog from ${LATEST_TAG}..HEAD" >> $RELEASE_NOTES
@@ -130,8 +131,8 @@ echo " > Verified ownership to $POD_NAME pod"
 echo "--- Releasing version $VERSION (tag: $VERSION_TAG)..."
 
 function restore_podspec {
-    if [ -f 'Nimble.podspec.backup' ]; then
-        mv -f Nimble.podspec{.backup,}
+    if [ -f "${PODSPEC}.backup" ]; then
+        mv -f ${PODSPEC}{.backup,}
     fi
 }
 
@@ -153,7 +154,7 @@ else
         die "Failed to update version in podspec"
     }
 
-    git add Nimble.podspec || { restore_podspec; die "Failed to add Nimble.podspec to INDEX"; }
+    git add ${PODSPEC} || { restore_podspec; die "Failed to add ${PODSPEC} to INDEX"; }
     git commit -m "Bumping version to $VERSION" || { restore_podspec; die "Failed to push updated version: $VERSION"; }
 fi
 
@@ -195,5 +196,4 @@ echo "   - Paste the contents of $RELEASE_NOTES into the release notes. Tweak fo
 echo "   - Attach ${CARTHAGE_FRAMEWORK_NAME}.framework.zip to it."
 echo " - Announce!"
 
-rm Nimble.podspec.backup
-
+rm ${PODSPEC}.backup

--- a/Carthage/Checkouts/Quick/CONTRIBUTING.md
+++ b/Carthage/Checkouts/Quick/CONTRIBUTING.md
@@ -32,6 +32,12 @@ it.
 - Went to the kitchen, only to forget why you went in the first place?
   Better submit an issue.
 
+Be sure to include in your issue:
+
+- Your Xcode version (eg - Xcode 7.0.1 7A1001)
+- Your version of Quick / Nimble (eg - v0.7.0 or git sha `7d0b8c21357839a8c5228863b77faecf709254a9`)
+- What are the steps to reproduce this issue?
+
 ## Building the Project
 
 - After cloning the repository, run `git submodule update --init` to pull the Nimble submodule.
@@ -50,10 +56,10 @@ it.
 - Be sure the unit tests for both the OS X and iOS targets of both Quick
   and Nimble pass before submitting your pull request. You can run all
   the iOS and OS X unit tests using `rake`.
-- To make minor updates to old versions of Quick that support Swift
-  1.1, issue a pull request against the `swift-1.1` branch. The master
-  branch supports Swift 1.2. Travis CI will only pass for pull requests
-  issued against the `swift-1.1` branch.
+- The `master` branch will always support the stable Xcode version. Other
+  branches will point to their corresponding versions they support.
+- If you're making a configuration change, make sure to edit both the xcode
+  project and the podspec file.
 
 ### Style Conventions
 
@@ -95,15 +101,8 @@ some "ground rules":
 
 The process is relatively straight forward, but here's is a useful checklist for tagging:
 
-- Bump the version in `Quick.podspec` (update, commit, push to github)
-- Look a changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
-    - The release notes should include user-facing information (api breakages, new features, bug fixes)
-- Tag the version: `git tag -s vA.B.C -F release-notes-file`
-- Push the tag: `git push origin vA.B.C`
-- Push the podspec file to trunk: `pod trunk push Quick.podspec`
-- Build the carthage pre-built binary:
-  - `carthage build --no-skip-current`
-  - `carthage archive Quick`
+- Look at changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
+- Run the release script: `./script/release A.B.C release-notes-file`
 - Go to [github releases](https://github.com/Quick/Quick/releases) and mark the tagged commit as a release.
   - Use the same release notes you created for the tag, but tweak up formatting for github.
   - Attach the carthage release `Quick.framework.zip` to the release.

--- a/Carthage/Checkouts/Quick/Externals/Nimble/.gitignore
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/.gitignore
@@ -4,3 +4,10 @@ build/
 .idea
 DerivedData/
 Nimble.framework.zip
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build

--- a/Carthage/Checkouts/Quick/Externals/Nimble/CONTRIBUTING.md
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/CONTRIBUTING.md
@@ -33,9 +33,15 @@ it.
 - Went to the kitchen, only to forget why you went in the first place?
   Better submit an issue.
 
+Be sure to include in your issue:
+
+- Your Xcode version (eg - Xcode 7.0.1 7A1001)
+- Your version of Nimble (eg - v2.0.0 or git sha `20a3f3b4e63cc8d97c92c4164bf36f2a2c9a6e1b`)
+- What are the steps to reproduce this issue?
+
 ## Building the Project
 
-- Use `Nimble.xcproj` to work on Nimble.
+- Use `Nimble.xcodeproj` to work on Nimble.
 
 ## Pull Requests
 
@@ -51,10 +57,8 @@ it.
   tests using `./test`.
 - If you've added a file to the project, make sure it's included in both
   the OS X and iOS targets.
-- To make minor updates to old versions of Nimble that support Swift
-  1.1, issue a pull request against the `swift-1.1` branch. The master
-  branch supports Swift 1.2. Travis CI will only pass for pull requests
-  issued against the `swift-1.1` branch.
+- The `master` branch will always support the stable Xcode version. Other
+  branches will point to their corresponding versions they support.
 - If you're making a configuration change, make sure to edit both the xcode
   project and the podspec file.
 
@@ -95,7 +99,7 @@ some "ground rules":
 
 The process is relatively straight forward, but here's is a useful checklist for tagging:
 
-- Look a changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
+- Look at changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
 - Run the release script: `./script/release A.B.C release-notes-file`
 - Go to [github releases](https://github.com/Quick/Nimble/releases) and mark the tagged commit as a release.
   - Use the same release notes you created for the tag, but tweak up formatting for github.

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.podspec
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Nimble"
-  s.version      = "2.0.0-rc.3"
+  s.version      = "3.0.0"
   s.summary      = "A Matcher Framework for Swift and Objective-C"
   s.description  = <<-DESC
                    Use Nimble to express the expected outcomes of Swift or Objective-C expressions. Inspired by Cedar.
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.author       = "Quick Contributors"
   s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.9"
+  s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/Quick/Nimble.git", :tag => "v#{s.version}" }
 
   s.source_files = "Nimble", "Nimble/**/*.{swift,h,m}"

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/project.pbxproj
@@ -66,6 +66,76 @@
 		1F4A569E1A3B3565009E1637 /* ObjCMatchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */; };
 		1F4A56A01A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */; };
 		1F4A56A11A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */; };
+		1F5DF15F1BDCA0CE00C3A531 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */; };
+		1F5DF16C1BDCA0F500C3A531 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD051968AB07008ED995 /* AssertionRecorder.swift */; };
+		1F5DF16D1BDCA0F500C3A531 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD061968AB07008ED995 /* AdapterProtocols.swift */; };
+		1F5DF16E1BDCA0F500C3A531 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD071968AB07008ED995 /* NimbleXCTestHandler.swift */; };
+		1F5DF16F1BDCA0F500C3A531 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
+		1F5DF1701BDCA0F500C3A531 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD081968AB07008ED995 /* DSL.swift */; };
+		1F5DF1711BDCA0F500C3A531 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
+		1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD091968AB07008ED995 /* Expectation.swift */; };
+		1F5DF1731BDCA0F500C3A531 /* ObjCExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0FEA991AF32DA4001E554E /* ObjCExpectation.swift */; };
+		1F5DF1741BDCA0F500C3A531 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0A1968AB07008ED995 /* Expression.swift */; };
+		1F5DF1751BDCA0F500C3A531 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0B1968AB07008ED995 /* FailureMessage.swift */; };
+		1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB1BC781A92235600F743C3 /* AllPass.swift */; };
+		1F5DF1771BDCA0F500C3A531 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0E1968AB07008ED995 /* BeAKindOf.swift */; };
+		1F5DF1781BDCA0F500C3A531 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0D1968AB07008ED995 /* BeAnInstanceOf.swift */; };
+		1F5DF1791BDCA0F500C3A531 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0F1968AB07008ED995 /* BeCloseTo.swift */; };
+		1F5DF17A1BDCA0F500C3A531 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD101968AB07008ED995 /* BeEmpty.swift */; };
+		1F5DF17B1BDCA0F500C3A531 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD111968AB07008ED995 /* BeginWith.swift */; };
+		1F5DF17C1BDCA0F500C3A531 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD121968AB07008ED995 /* BeGreaterThan.swift */; };
+		1F5DF17D1BDCA0F500C3A531 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD131968AB07008ED995 /* BeGreaterThanOrEqualTo.swift */; };
+		1F5DF17E1BDCA0F500C3A531 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD141968AB07008ED995 /* BeIdenticalTo.swift */; };
+		1F5DF17F1BDCA0F500C3A531 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD151968AB07008ED995 /* BeLessThan.swift */; };
+		1F5DF1801BDCA0F500C3A531 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD161968AB07008ED995 /* BeLessThanOrEqual.swift */; };
+		1F5DF1811BDCA0F500C3A531 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD171968AB07008ED995 /* BeLogical.swift */; };
+		1F5DF1821BDCA0F500C3A531 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD181968AB07008ED995 /* BeNil.swift */; };
+		1F5DF1831BDCA0F500C3A531 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1A1968AB07008ED995 /* Contain.swift */; };
+		1F5DF1841BDCA0F500C3A531 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1B1968AB07008ED995 /* EndWith.swift */; };
+		1F5DF1851BDCA0F500C3A531 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
+		1F5DF1861BDCA0F500C3A531 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
+		1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EC19FE43C200E9D9FE /* Match.swift */; };
+		1F5DF1881BDCA0F500C3A531 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
+		1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
+		1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
+		1F5DF18B1BDCA0F500C3A531 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD251968AB07008ED995 /* Functional.swift */; };
+		1F5DF18C1BDCA0F500C3A531 /* Poll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Poll.swift */; };
+		1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD271968AB07008ED995 /* SourceLocation.swift */; };
+		1F5DF18E1BDCA0F500C3A531 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD281968AB07008ED995 /* Stringers.swift */; };
+		1F5DF18F1BDCA0F500C3A531 /* AsyncMatcherWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2A1968AB07008ED995 /* AsyncMatcherWrapper.swift */; };
+		1F5DF1901BDCA0F500C3A531 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */; };
+		1F5DF1911BDCA0F500C3A531 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
+		1F5DF1921BDCA10200C3A531 /* AsynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE5195C121200ED456B /* AsynchronousTest.swift */; };
+		1F5DF1931BDCA10200C3A531 /* SynchronousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648D31963AAB2001F9C46 /* SynchronousTests.swift */; };
+		1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
+		1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14FB63194180C5009F2A08 /* utils.swift */; };
+		1F5DF1961BDCA10200C3A531 /* ObjectWithLazyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648CB19639F5A001F9C46 /* ObjectWithLazyProperty.swift */; };
+		1F5DF1971BDCA10200C3A531 /* AllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD72EC631A93874A002F7651 /* AllPassTest.swift */; };
+		1F5DF1981BDCA10200C3A531 /* BeAKindOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B5AD31963E13900CA8BF9 /* BeAKindOfTest.swift */; };
+		1F5DF1991BDCA10200C3A531 /* BeAnInstanceOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */; };
+		1F5DF19A1BDCA10200C3A531 /* BeCloseToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EF5195C147800ED456B /* BeCloseToTest.swift */; };
+		1F5DF19B1BDCA10200C3A531 /* BeEmptyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F299EAA19627B2D002641AF /* BeEmptyTest.swift */; };
+		1F5DF19C1BDCA10200C3A531 /* BeginWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EFB195C186800ED456B /* BeginWithTest.swift */; };
+		1F5DF19D1BDCA10200C3A531 /* BeGreaterThanOrEqualToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F10195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift */; };
+		1F5DF19E1BDCA10200C3A531 /* BeGreaterThanTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F07195C18CF00ED456B /* BeGreaterThanTest.swift */; };
+		1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */; };
+		1F5DF1A01BDCA10200C3A531 /* BeIdenticalToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB90097195EC4B8001D7FAE /* BeIdenticalToTest.swift */; };
+		1F5DF1A11BDCA10200C3A531 /* BeLessThanOrEqualToTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F0D195C18F500ED456B /* BeLessThanOrEqualToTest.swift */; };
+		1F5DF1A21BDCA10200C3A531 /* BeLessThanTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F0A195C18E100ED456B /* BeLessThanTest.swift */; };
+		1F5DF1A31BDCA10200C3A531 /* BeLogicalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EEE195C136500ED456B /* BeLogicalTest.swift */; };
+		1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EF8195C175000ED456B /* BeNilTest.swift */; };
+		1F5DF1A51BDCA10200C3A531 /* ContainTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F01195C189500ED456B /* ContainTest.swift */; };
+		1F5DF1A61BDCA10200C3A531 /* EndWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EFE195C187600ED456B /* EndWithTest.swift */; };
+		1F5DF1A71BDCA10200C3A531 /* EqualTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925F04195C18B700ED456B /* EqualTest.swift */; };
+		1F5DF1A81BDCA10200C3A531 /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
+		1F5DF1A91BDCA10200C3A531 /* MatchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EF19FE442800E9D9FE /* MatchTest.swift */; };
+		1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */; };
+		1F5DF1AB1BDCA10200C3A531 /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
+		1F5DF1AC1BDCA16E00C3A531 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD211968AB07008ED995 /* DSL.m */; };
+		1F5DF1AD1BDCA16E00C3A531 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD231968AB07008ED995 /* NMBExceptionCapture.m */; };
+		1F5DF1AE1BDCA17600C3A531 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1A742E1940169200FFFC47 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F5DF1AF1BDCA17600C3A531 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD8CD201968AB07008ED995 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F5DF1B01BDCA17600C3A531 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD8CD221968AB07008ED995 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F8A37B01B7C5042001C8357 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
 		1F8A37B11B7C5042001C8357 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
 		1F925EB8195C0D6300ED456B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F925EAD195C0D6300ED456B /* Nimble.framework */; };
@@ -173,12 +243,12 @@
 		29EA59641B551ED2002D767E /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
 		29EA59661B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
 		29EA59671B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
-		472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; settings = {ASSET_TAGS = (); }; };
+		472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD1391B9E0A9700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD13A1B9E0A9F00C7B8DA /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
 		472FD13B1B9E0CFE00C7B8DA /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
-		4793854D1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; settings = {ASSET_TAGS = (); }; };
-		4793854E1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; settings = {ASSET_TAGS = (); }; };
+		4793854D1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; };
+		4793854E1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */ = {isa = PBXBuildFile; fileRef = 4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */; };
 		965B0D091B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0A1B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0C1B62C06D0005AE66 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
@@ -206,6 +276,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1F1A74281940169200FFFC47;
 			remoteInfo = "Nimble-iOS";
+		};
+		1F5DF1601BDCA0CE00C3A531 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1F1A74201940169200FFFC47 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F5DF1541BDCA0CE00C3A531;
+			remoteInfo = "Nimble-tvOS";
 		};
 		1F6BB82A1968BFF9009F1DBB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -292,6 +369,8 @@
 		1F4A56991A3B3539009E1637 /* ObjCEqualTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCEqualTest.m; sourceTree = "<group>"; };
 		1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCMatchTest.m; sourceTree = "<group>"; };
 		1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCRaiseExceptionTest.m; sourceTree = "<group>"; };
+		1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F5DF15E1BDCA0CE00C3A531 /* NimbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSyncTest.m; sourceTree = "<group>"; };
 		1F925EAD195C0D6300ED456B /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F925EB7195C0D6300ED456B /* NimbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -381,6 +460,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1F5DF1511BDCA0CE00C3A531 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF15B1BDCA0CE00C3A531 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF15F1BDCA0CE00C3A531 /* Nimble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1F925EA9195C0D6300ED456B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -425,6 +519,8 @@
 				1F1A74341940169200FFFC47 /* NimbleTests.xctest */,
 				1F925EAD195C0D6300ED456B /* Nimble.framework */,
 				1F925EB7195C0D6300ED456B /* NimbleTests.xctest */,
+				1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */,
+				1F5DF15E1BDCA0CE00C3A531 /* NimbleTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -609,7 +705,6 @@
 				1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */,
 				965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */,
 				DDEFAEB31A93CBE6005CA37A /* ObjCAllPassTest.m */,
-				30FC9B081B7E48670097E2D6 /* ObjCSyncTest.m */,
 			);
 			path = objc;
 			sourceTree = "<group>";
@@ -624,6 +719,16 @@
 				1FD8CD601968AB07008ED995 /* DSL.h in Headers */,
 				1FD8CD641968AB07008ED995 /* NMBExceptionCapture.h in Headers */,
 				1F1A742F1940169200FFFC47 /* Nimble.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF1521BDCA0CE00C3A531 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF1AF1BDCA17600C3A531 /* DSL.h in Headers */,
+				1F5DF1B01BDCA17600C3A531 /* NMBExceptionCapture.h in Headers */,
+				1F5DF1AE1BDCA17600C3A531 /* Nimble.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -679,6 +784,42 @@
 			productReference = 1F1A74341940169200FFFC47 /* NimbleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		1F5DF1541BDCA0CE00C3A531 /* Nimble-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F5DF16A1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOS" */;
+			buildPhases = (
+				1F5DF1501BDCA0CE00C3A531 /* Sources */,
+				1F5DF1511BDCA0CE00C3A531 /* Frameworks */,
+				1F5DF1521BDCA0CE00C3A531 /* Headers */,
+				1F5DF1531BDCA0CE00C3A531 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Nimble-tvOS";
+			productName = "Nimble-tvOS";
+			productReference = 1F5DF1551BDCA0CE00C3A531 /* Nimble.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F5DF15D1BDCA0CE00C3A531 /* Nimble-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F5DF16B1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOSTests" */;
+			buildPhases = (
+				1F5DF15A1BDCA0CE00C3A531 /* Sources */,
+				1F5DF15B1BDCA0CE00C3A531 /* Frameworks */,
+				1F5DF15C1BDCA0CE00C3A531 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1F5DF1611BDCA0CE00C3A531 /* PBXTargetDependency */,
+			);
+			name = "Nimble-tvOSTests";
+			productName = "Nimble-tvOSTests";
+			productReference = 1F5DF15E1BDCA0CE00C3A531 /* NimbleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		1F925EAC195C0D6300ED456B /* Nimble-OSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1F925EC0195C0D6300ED456B /* Build configuration list for PBXNativeTarget "Nimble-OSX" */;
@@ -724,8 +865,8 @@
 		1F1A74201940169200FFFC47 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Jeff Hui";
 				TargetAttributes = {
 					1F1A74281940169200FFFC47 = {
@@ -734,6 +875,12 @@
 					1F1A74331940169200FFFC47 = {
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = 1F1A74281940169200FFFC47;
+					};
+					1F5DF1541BDCA0CE00C3A531 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+					1F5DF15D1BDCA0CE00C3A531 = {
+						CreatedOnToolsVersion = 7.1;
 					};
 					1F925EAC195C0D6300ED456B = {
 						CreatedOnToolsVersion = 6.0;
@@ -760,6 +907,8 @@
 				1F1A74331940169200FFFC47 /* Nimble-iOSTests */,
 				1F925EAC195C0D6300ED456B /* Nimble-OSX */,
 				1F925EB6195C0D6300ED456B /* Nimble-OSXTests */,
+				1F5DF1541BDCA0CE00C3A531 /* Nimble-tvOS */,
+				1F5DF15D1BDCA0CE00C3A531 /* Nimble-tvOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -773,6 +922,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1F1A74321940169200FFFC47 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF1531BDCA0CE00C3A531 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF15C1BDCA0CE00C3A531 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -867,7 +1030,6 @@
 				1F925F0B195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FB1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
 				1FB90098195EC4B8001D7FAE /* BeIdenticalToTest.swift in Sources */,
-				30FC9B091B7E48670097E2D6 /* ObjCSyncTest.m in Sources */,
 				1F4A56761A3B3253009E1637 /* ObjCBeGreaterThanTest.m in Sources */,
 				1F925EF9195C175000ED456B /* BeNilTest.swift in Sources */,
 				1F4A56701A3B319F009E1637 /* ObjCBeCloseToTest.m in Sources */,
@@ -899,6 +1061,86 @@
 				29EA59631B551ED2002D767E /* ThrowErrorTest.swift in Sources */,
 				1F4A566A1A3B3108009E1637 /* ObjCBeAnInstanceOfTest.m in Sources */,
 				472FD13B1B9E0CFE00C7B8DA /* HaveCountTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF1501BDCA0CE00C3A531 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF1791BDCA0F500C3A531 /* BeCloseTo.swift in Sources */,
+				1F5DF16C1BDCA0F500C3A531 /* AssertionRecorder.swift in Sources */,
+				1F5DF1881BDCA0F500C3A531 /* MatcherProtocols.swift in Sources */,
+				1F5DF16E1BDCA0F500C3A531 /* NimbleXCTestHandler.swift in Sources */,
+				1F5DF1751BDCA0F500C3A531 /* FailureMessage.swift in Sources */,
+				1F5DF1801BDCA0F500C3A531 /* BeLessThanOrEqual.swift in Sources */,
+				1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */,
+				1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */,
+				1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */,
+				1F5DF1861BDCA0F500C3A531 /* HaveCount.swift in Sources */,
+				1F5DF1811BDCA0F500C3A531 /* BeLogical.swift in Sources */,
+				1F5DF1741BDCA0F500C3A531 /* Expression.swift in Sources */,
+				1F5DF1911BDCA0F500C3A531 /* ObjCMatcher.swift in Sources */,
+				1F5DF1781BDCA0F500C3A531 /* BeAnInstanceOf.swift in Sources */,
+				1F5DF1771BDCA0F500C3A531 /* BeAKindOf.swift in Sources */,
+				1F5DF17F1BDCA0F500C3A531 /* BeLessThan.swift in Sources */,
+				1F5DF17C1BDCA0F500C3A531 /* BeGreaterThan.swift in Sources */,
+				1F5DF1831BDCA0F500C3A531 /* Contain.swift in Sources */,
+				1F5DF1731BDCA0F500C3A531 /* ObjCExpectation.swift in Sources */,
+				1F5DF1851BDCA0F500C3A531 /* Equal.swift in Sources */,
+				1F5DF18F1BDCA0F500C3A531 /* AsyncMatcherWrapper.swift in Sources */,
+				1F5DF1711BDCA0F500C3A531 /* DSL+Wait.swift in Sources */,
+				1F5DF17D1BDCA0F500C3A531 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				1F5DF18E1BDCA0F500C3A531 /* Stringers.swift in Sources */,
+				1F5DF1AD1BDCA16E00C3A531 /* NMBExceptionCapture.m in Sources */,
+				1F5DF16D1BDCA0F500C3A531 /* AdapterProtocols.swift in Sources */,
+				1F5DF17B1BDCA0F500C3A531 /* BeginWith.swift in Sources */,
+				1F5DF17E1BDCA0F500C3A531 /* BeIdenticalTo.swift in Sources */,
+				1F5DF17A1BDCA0F500C3A531 /* BeEmpty.swift in Sources */,
+				1F5DF18C1BDCA0F500C3A531 /* Poll.swift in Sources */,
+				1F5DF1821BDCA0F500C3A531 /* BeNil.swift in Sources */,
+				1F5DF1AC1BDCA16E00C3A531 /* DSL.m in Sources */,
+				1F5DF16F1BDCA0F500C3A531 /* AssertionDispatcher.swift in Sources */,
+				1F5DF1841BDCA0F500C3A531 /* EndWith.swift in Sources */,
+				1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */,
+				1F5DF1701BDCA0F500C3A531 /* DSL.swift in Sources */,
+				1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */,
+				1F5DF18B1BDCA0F500C3A531 /* Functional.swift in Sources */,
+				1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */,
+				1F5DF1901BDCA0F500C3A531 /* MatcherFunc.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F5DF15A1BDCA0CE00C3A531 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F5DF1A31BDCA10200C3A531 /* BeLogicalTest.swift in Sources */,
+				1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */,
+				1F5DF1981BDCA10200C3A531 /* BeAKindOfTest.swift in Sources */,
+				1F5DF19B1BDCA10200C3A531 /* BeEmptyTest.swift in Sources */,
+				1F5DF1A11BDCA10200C3A531 /* BeLessThanOrEqualToTest.swift in Sources */,
+				1F5DF1961BDCA10200C3A531 /* ObjectWithLazyProperty.swift in Sources */,
+				1F5DF1AB1BDCA10200C3A531 /* ThrowErrorTest.swift in Sources */,
+				1F5DF1A51BDCA10200C3A531 /* ContainTest.swift in Sources */,
+				1F5DF19E1BDCA10200C3A531 /* BeGreaterThanTest.swift in Sources */,
+				1F5DF1A21BDCA10200C3A531 /* BeLessThanTest.swift in Sources */,
+				1F5DF1921BDCA10200C3A531 /* AsynchronousTest.swift in Sources */,
+				1F5DF1A91BDCA10200C3A531 /* MatchTest.swift in Sources */,
+				1F5DF1A81BDCA10200C3A531 /* HaveCountTest.swift in Sources */,
+				1F5DF1971BDCA10200C3A531 /* AllPassTest.swift in Sources */,
+				1F5DF19C1BDCA10200C3A531 /* BeginWithTest.swift in Sources */,
+				1F5DF1A01BDCA10200C3A531 /* BeIdenticalToTest.swift in Sources */,
+				1F5DF19A1BDCA10200C3A531 /* BeCloseToTest.swift in Sources */,
+				1F5DF1A61BDCA10200C3A531 /* EndWithTest.swift in Sources */,
+				1F5DF1A71BDCA10200C3A531 /* EqualTest.swift in Sources */,
+				1F5DF1931BDCA10200C3A531 /* SynchronousTests.swift in Sources */,
+				1F5DF19D1BDCA10200C3A531 /* BeGreaterThanOrEqualToTest.swift in Sources */,
+				1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */,
+				1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */,
+				1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */,
+				1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */,
+				1F5DF1991BDCA10200C3A531 /* BeAnInstanceOfTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -973,7 +1215,6 @@
 				1F925F0C195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FC1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
 				1FB90099195EC4B8001D7FAE /* BeIdenticalToTest.swift in Sources */,
-				30FC9B0A1B7E48670097E2D6 /* ObjCSyncTest.m in Sources */,
 				1F4A56771A3B3253009E1637 /* ObjCBeGreaterThanTest.m in Sources */,
 				1F925EFA195C175000ED456B /* BeNilTest.swift in Sources */,
 				1F4A56711A3B319F009E1637 /* ObjCBeCloseToTest.m in Sources */,
@@ -1015,6 +1256,11 @@
 			isa = PBXTargetDependency;
 			target = 1F1A74281940169200FFFC47 /* Nimble-iOS */;
 			targetProxy = 1F1A74361940169200FFFC47 /* PBXContainerItemProxy */;
+		};
+		1F5DF1611BDCA0CE00C3A531 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F5DF1541BDCA0CE00C3A531 /* Nimble-tvOS */;
+			targetProxy = 1F5DF1601BDCA0CE00C3A531 /* PBXContainerItemProxy */;
 		};
 		1F6BB82B1968BFF9009F1DBB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1075,8 +1321,8 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1123,7 +1369,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1151,6 +1396,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -1166,10 +1412,11 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1183,6 +1430,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -1197,10 +1445,11 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 			};
 			name = Release;
@@ -1220,6 +1469,7 @@
 				INFOPLIST_FILE = NimbleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/NimbleTests-Bridging-Header.h";
@@ -1238,9 +1488,114 @@
 				INFOPLIST_FILE = NimbleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/NimbleTests-Bridging-Header.h";
+			};
+			name = Release;
+		};
+		1F5DF1661BDCA0CE00C3A531 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Nimble/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					XCTest,
+					"-weak-lswiftXCTest",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_MODULE_NAME = Nimble;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F5DF1671BDCA0CE00C3A531 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Nimble/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					XCTest,
+					"-weak-lswiftXCTest",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_MODULE_NAME = Nimble;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		1F5DF1681BDCA0CE00C3A531 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = NimbleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = NimbleTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F5DF1691BDCA0CE00C3A531 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = NimbleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = NimbleTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -1272,6 +1627,7 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
@@ -1306,6 +1662,7 @@
 					XCTest,
 					"-weak-lswiftXCTest",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
@@ -1332,6 +1689,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/Nimble-OSXTests-Bridging-Header.h";
@@ -1353,6 +1711,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "NimbleTests/objc/Nimble-OSXTests-Bridging-Header.h";
@@ -1385,6 +1744,24 @@
 			buildConfigurations = (
 				1F1A74431940169200FFFC47 /* Debug */,
 				1F1A74441940169200FFFC47 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F5DF16A1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F5DF1661BDCA0CE00C3A531 /* Debug */,
+				1F5DF1671BDCA0CE00C3A531 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F5DF16B1BDCA0CE00C3A531 /* Build configuration list for PBXNativeTarget "Nimble-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F5DF1681BDCA0CE00C3A531 /* Debug */,
+				1F5DF1691BDCA0CE00C3A531 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-OSX.xcscheme
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -43,11 +43,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugXPCServices = "NO"
@@ -66,10 +66,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -43,11 +43,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugXPCServices = "NO"
@@ -66,10 +66,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0710"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F1A74281940169200FFFC47"
+               BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
                BuildableName = "Nimble.framework"
-               BlueprintName = "Nimble-iOS"
+               BlueprintName = "Nimble-tvOS"
                ReferencedContainer = "container:Nimble.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,33 +32,41 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F1A74331940169200FFFC47"
+               BlueprintIdentifier = "1F5DF15D1BDCA0CE00C3A531"
                BuildableName = "NimbleTests.xctest"
-               BlueprintName = "Nimble-iOSTests"
+               BlueprintName = "Nimble-tvOSTests"
                ReferencedContainer = "container:Nimble.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
+            BuildableName = "Nimble.framework"
+            BlueprintName = "Nimble-tvOS"
+            ReferencedContainer = "container:Nimble.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      debugXPCServices = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1F1A74281940169200FFFC47"
+            BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
             BuildableName = "Nimble.framework"
-            BlueprintName = "Nimble-iOS"
+            BlueprintName = "Nimble-tvOS"
             ReferencedContainer = "container:Nimble.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -71,6 +79,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F5DF1541BDCA0CE00C3A531"
+            BuildableName = "Nimble.framework"
+            BlueprintName = "Nimble-tvOS"
+            ReferencedContainer = "container:Nimble.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/DSL+Wait.swift
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/DSL+Wait.swift
@@ -38,13 +38,6 @@ internal class NMBWait: NSObject {
 /// Wait asynchronously until the done closure is called.
 ///
 /// This will advance the run loop.
-public func waitUntil(timeout timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
-}
-
-/// Wait asynchronously until the done closure is called.
-///
-/// This will advance the run loop.
-public func waitUntil(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
-    NMBWait.until(timeout: 1, file: file, line: line, action: action)
 }

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/Info.plist
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.jeffhui.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -20,9 +20,9 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014 Jeff Hui. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/Matchers/HaveCount.swift
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/Matchers/HaveCount.swift
@@ -5,9 +5,9 @@ import Foundation
 public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(actualValue.count)"
+            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
             let result = expectedValue == actualValue.count
-            failureMessage.actualValue = "\(expectedValue)"
+            failureMessage.actualValue = "\(actualValue.count)"
             return result
         } else {
             return false
@@ -20,9 +20,9 @@ public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> Non
 public func haveCount(expectedValue: Int) -> MatcherFunc<NMBCollection> {
     return MatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(actualValue.count)"
+            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
             let result = expectedValue == actualValue.count
-            failureMessage.actualValue = "\(expectedValue)"
+            failureMessage.actualValue = "\(actualValue.count)"
             return result
         } else {
             return false

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/Nimble.h
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble/Nimble.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
-#import <Nimble/NMBExceptionCapture.h>
-#import <Nimble/DSL.h>
+#import "NMBExceptionCapture.h"
+#import "DSL.h"
 
 FOUNDATION_EXPORT double NimbleVersionNumber;
 FOUNDATION_EXPORT const unsigned char NimbleVersionString[];

--- a/Carthage/Checkouts/Quick/Externals/Nimble/NimbleTests/Info.plist
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/NimbleTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.jeffhui.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Carthage/Checkouts/Quick/Externals/Nimble/NimbleTests/Matchers/HaveCountTest.swift
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/NimbleTests/Matchers/HaveCountTest.swift
@@ -6,7 +6,7 @@ class HaveCountTest: XCTestCase {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [1, 2, 3] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [1, 2, 3] with count 1, got 3") {
             expect([1, 2, 3]).to(haveCount(1))
         }
 
@@ -19,7 +19,7 @@ class HaveCountTest: XCTestCase {
         expect(["1":1, "2":2, "3":3]).to(haveCount(3))
         expect(["1":1, "2":2, "3":3]).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 1, got 3") {
             expect(["1":1, "2":2, "3":3]).to(haveCount(1))
         }
 
@@ -32,7 +32,7 @@ class HaveCountTest: XCTestCase {
         expect(Set([1, 2, 3])).to(haveCount(3))
         expect(Set([1, 2, 3])).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [2, 3, 1] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [2, 3, 1] with count 1, got 3") {
             expect(Set([1, 2, 3])).to(haveCount(1))
         }
 

--- a/Carthage/Checkouts/Quick/Externals/Nimble/NimbleTests/objc/ObjCHaveCount.m
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/NimbleTests/objc/ObjCHaveCount.m
@@ -14,7 +14,7 @@
     expect(@[]).to(haveCount(@0));
     expect(@[@1]).notTo(haveCount(@0));
 
-    expectFailureMessage(@"expected to have (1,2,3) with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have (1,2,3) with count 1, got 3", ^{
         expect(@[@1, @2, @3]).to(haveCount(@1));
     });
 
@@ -28,7 +28,7 @@
     expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@3));
     expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have {1 = 1;2 = 2;3 = 3;} with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have {1 = 1;2 = 2;3 = 3;} with count 1, got 3", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@1));
     });
 
@@ -46,7 +46,7 @@
     expect(table).to(haveCount(@3));
     expect(table).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3", ^{
         expect(table).to(haveCount(@1));
     });
 
@@ -61,7 +61,7 @@
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have {(3,1,2)} with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have {(3,1,2)} with count 1, got 3", ^{
         expect(set).to(haveCount(@1));
     });
 

--- a/Carthage/Checkouts/Quick/Externals/Nimble/README.md
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/README.md
@@ -475,10 +475,6 @@ expect(actual).to(beIdenticalTo(expected));
 expect(actual).toNot(beIdenticalTo(expected));
 ```
 
-> `beIdenticalTo` only supports Objective-C objects: subclasses
-  of `NSObject`, or Swift objects bridged to Objective-C with the
-  `@objc` prefix.
-
 ## Comparisons
 
 ```swift
@@ -1127,11 +1123,9 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'YOUR_APP_NAME_HERE_Tests', :exclusive => true do
   use_frameworks!
   # If you're using Swift 2.0 (Xcode 7), use this:
-  pod 'Nimble', '2.0.0-rc.2'
+  pod 'Nimble', '~> 2.0.0'
   # If you're using Swift 1.2 (Xcode 6), use this:
   pod 'Nimble', '~> 1.0.0'
-  # Otherwise, use this commented out line for Swift 1.1 (Xcode 6.2):
-  # pod 'Nimble', '~> 0.3.0'
 end
 ```
 

--- a/Carthage/Checkouts/Quick/Externals/Nimble/script/release
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/script/release
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-REMOTE_BRANCH=swift-2.0
+REMOTE_BRANCH=master
 POD_NAME=Nimble
 PODSPEC=Nimble.podspec
 GITHUB_TAGS_URL=https://github.com/Quick/Nimble/tags
@@ -13,6 +13,7 @@ function help {
     echo
     echo "VERSION should be the version to release, should not include the 'v' prefix"
     echo "RELEASE_NOTES should be a file that lists all the release notes for this version"
+    echo "              if file does not exist, creates a git-style commit with a diff as a comment"
     echo
     echo "FLAGS"
     echo "  -f  Forces override of tag"
@@ -65,7 +66,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo " > Is this version ($VERSION) unique?"
-git describe --exact-match "$VERSION_TAG" 2>&1 > /dev/null
+git describe --exact-match "$VERSION_TAG" > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     if [ -z "$FORCE_TAG" ]; then
         die "This tag ($VERSION) already exists. Aborting. Append '-f' to override"
@@ -77,7 +78,23 @@ else
 fi
 
 if [ ! -f "$RELEASE_NOTES" ]; then
-    die "Failed to find $RELEASE_NOTES. Aborting."
+    echo " > Failed to find $RELEASE_NOTES. Prompting editor"
+    RELEASE_NOTES=.release-changes
+    LATEST_TAG=`git for-each-ref refs/tags --sort=-refname --format="%(refname:short)" | grep -E "^v\d+\.\d+\.\d+(-\w+(\.\d)?)?\$" | ruby -e 'puts STDIN.read.split("\n").sort { |a,b| Gem::Version.new(a.gsub(/^v/, "")) <=> Gem::Version.new(b.gsub(/^v/, "")) }.last'`
+    echo " > Latest tag ${LATEST_TAG}"
+    echo "${POD_NAME} v$VERSION" > $RELEASE_NOTES
+    echo "================" >> $RELEASE_NOTES
+    echo >> $RELEASE_NOTES
+    echo "# Changelog from ${LATEST_TAG}..HEAD" >> $RELEASE_NOTES
+    git log ${LATEST_TAG}..HEAD | sed -e 's/^/# /' >> $RELEASE_NOTES
+    $EDITOR $RELEASE_NOTES
+    diff -q $RELEASE_NOTES ${RELEASE_NOTES}.backup > /dev/null 2>&1
+    STATUS=$?
+    rm ${RELEASE_NOTES}.backup
+    if [ $STATUS -eq 0 ]; then
+        rm $RELEASE_NOTES
+        die "No changes in release notes file. Aborting."
+    fi
 fi
 echo " > Release notes: $RELEASE_NOTES"
 
@@ -114,8 +131,8 @@ echo " > Verified ownership to $POD_NAME pod"
 echo "--- Releasing version $VERSION (tag: $VERSION_TAG)..."
 
 function restore_podspec {
-    if [ -f 'Nimble.podspec.backup' ]; then
-        mv -f Nimble.podspec{.backup,}
+    if [ -f "${PODSPEC}.backup" ]; then
+        mv -f ${PODSPEC}{.backup,}
     fi
 }
 
@@ -128,7 +145,8 @@ $CARTHAGE build --no-skip-current || die "Failed to build framework for carthage
 
 echo "-> Setting podspec version"
 cat "$PODSPEC" | grep 's.version' | grep -q "\"$VERSION\""
-if [ $? -eq 0 ]; then
+SET_PODSPEC_VERSION=$?
+if [ $SET_PODSPEC_VERSION -eq 0 ]; then
     echo " > Podspec already set to $VERSION. Skipping."
 else
     sed -i.backup "s/s.version *= *\".*\"/s.version      = \"$VERSION\"/g" "$PODSPEC" || {
@@ -136,10 +154,8 @@ else
         die "Failed to update version in podspec"
     }
 
-    git add Nimble.podspec || { restore_podspec; die "Failed to add Nimble.podspec to INDEX"; }
+    git add ${PODSPEC} || { restore_podspec; die "Failed to add ${PODSPEC} to INDEX"; }
     git commit -m "Bumping version to $VERSION" || { restore_podspec; die "Failed to push updated version: $VERSION"; }
-    git push origin "$REMOTE_BRANCH" || die "Failed to push to origin"
-    echo " > Pushed version to origin"
 fi
 
 if [ -z "$FORCE_TAG" ]; then
@@ -152,6 +168,12 @@ else
     git tag -f -s "$VERSION_TAG" -F "$RELEASE_NOTES" || die "Failed to tag version"
     echo "-> Pushing tag to origin (force)"
     git push origin "$VERSION_TAG" -f || die "Failed to push tag '$VERSION_TAG' to origin"
+fi
+
+if [ $SET_PODSPEC_VERSION -ne 0 ]; then
+    rm $RELEASE_NOTES
+    git push origin "$REMOTE_BRANCH" || die "Failed to push to origin"
+    echo " > Pushed version to origin"
 fi
 
 echo
@@ -174,5 +196,4 @@ echo "   - Paste the contents of $RELEASE_NOTES into the release notes. Tweak fo
 echo "   - Attach ${CARTHAGE_FRAMEWORK_NAME}.framework.zip to it."
 echo " - Announce!"
 
-rm Nimble.podspec.backup
-
+rm ${PODSPEC}.backup

--- a/Carthage/Checkouts/Quick/Quick.podspec
+++ b/Carthage/Checkouts/Quick/Quick.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Quick"
-  s.version      = "0.7.0"
+  s.version      = "0.8.0"
   s.summary      = "The Swift (and Objective-C) testing framework."
 
   s.description  = <<-DESC
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author       = "Quick Contributors"
   s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.9"
-  #s.tvos.deployment_target = '9.0'
+  s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => "https://github.com/Quick/Quick.git", :tag => "v#{s.version}" }
   s.source_files  = "Quick", "Quick/**/*.{swift,h,m}"

--- a/Carthage/Checkouts/Quick/Quick.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Quick/Quick.xcodeproj/project.pbxproj
@@ -7,6 +7,61 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F118CDF1BDCA4AB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
+		1F118CF51BDCA4BB005013A2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118CD51BDCA4AB005013A2 /* Quick.framework */; };
+		1F118CFB1BDCA536005013A2 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE714FD19FF6A62005905B8 /* QuickConfiguration.m */; };
+		1F118CFC1BDCA536005013A2 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA169E4719FF5DF100619816 /* Configuration.swift */; };
+		1F118CFD1BDCA536005013A2 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3124E519FCAEE8002858A7 /* World+DSL.swift */; };
+		1F118CFE1BDCA536005013A2 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3124E219FCAEE8002858A7 /* DSL.swift */; };
+		1F118CFF1BDCA536005013A2 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = DA3124E419FCAEE8002858A7 /* QCKDSL.m */; };
+		1F118D001BDCA536005013A2 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BDF19FF5599005DF92A /* Closures.swift */; };
+		1F118D011BDCA536005013A2 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BE019FF5599005DF92A /* ExampleHooks.swift */; };
+		1F118D021BDCA536005013A2 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA408BE119FF5599005DF92A /* SuiteHooks.swift */; };
+		1F118D031BDCA536005013A2 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F375A619515CA700CE1B99 /* World.swift */; };
+		1F118D041BDCA536005013A2 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F3759E19515CA700CE1B99 /* Example.swift */; };
+		1F118D051BDCA536005013A2 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02C91819A8073100093156 /* ExampleMetadata.swift */; };
+		1F118D061BDCA536005013A2 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F3759F19515CA700CE1B99 /* ExampleGroup.swift */; };
+		1F118D071BDCA536005013A2 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F3759C19515CA700CE1B99 /* Callsite.swift */; };
+		1F118D081BDCA536005013A2 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6B30171A4DB0D500FFB148 /* Filter.swift */; };
+		1F118D091BDCA536005013A2 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F375A519515CA700CE1B99 /* QuickSpec.m */; };
+		1F118D0A1BDCA536005013A2 /* NSString+QCKSelectorName.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F375A119515CA700CE1B99 /* NSString+QCKSelectorName.m */; };
+		1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8C00201A01E4B900CE58A6 /* QuickConfigurationTests.m */; };
+		1F118D0D1BDCA547005013A2 /* QCKSpecRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8F919619F31680006F6675 /* QCKSpecRunner.m */; };
+		1F118D0E1BDCA547005013A2 /* QCKSpecRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8F919619F31680006F6675 /* QCKSpecRunner.m */; };
+		1F118D0F1BDCA54B005013A2 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F91AD19F32CE2006F6675 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift */; };
+		1F118D101BDCA556005013A2 /* Configuration+AfterEach.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE714F619FF6812005905B8 /* Configuration+AfterEach.swift */; };
+		1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE714F919FF682A005905B8 /* Configuration+AfterEachTests.swift */; };
+		1F118D121BDCA556005013A2 /* ItTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7AE6F019FC493F000AFDCE /* ItTests.swift */; };
+		1F118D131BDCA556005013A2 /* ItTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 479C31E11A36156E00DA8718 /* ItTests+ObjC.m */; };
+		1F118D141BDCA556005013A2 /* FailureTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8F919C19F31921006F6675 /* FailureTests+ObjC.m */; };
+		1F118D151BDCA556005013A2 /* FailureUsingXCTAssertTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8940EF1B35B1FA00161061 /* FailureUsingXCTAssertTests+ObjC.m */; };
+		1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA87078219F48775008C04AC /* BeforeEachTests.swift */; };
+		1F118D171BDCA556005013A2 /* BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FAEA341A3F45ED005A1D2F /* BeforeEachTests+ObjC.m */; };
+		1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA05D60F19F73A3800771050 /* AfterEachTests.swift */; };
+		1F118D191BDCA556005013A2 /* AfterEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 470D6EC91A43409600043E50 /* AfterEachTests+ObjC.m */; };
+		1F118D1A1BDCA556005013A2 /* PendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA63EA219F7637300CD0A3B /* PendingTests.swift */; };
+		1F118D1B1BDCA556005013A2 /* PendingTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 4715903F1A488F3F00FBA644 /* PendingTests+ObjC.m */; };
+		1F118D1C1BDCA556005013A2 /* BeforeSuiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F91A419F3208B006F6675 /* BeforeSuiteTests.swift */; };
+		1F118D1D1BDCA556005013A2 /* BeforeSuiteTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 47876F7B1A4999B0002575C7 /* BeforeSuiteTests+ObjC.m */; };
+		1F118D1E1BDCA556005013A2 /* AfterSuiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F91A719F32556006F6675 /* AfterSuiteTests.swift */; };
+		1F118D1F1BDCA556005013A2 /* AfterSuiteTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 477217391A59C1B00022013E /* AfterSuiteTests+ObjC.m */; };
+		1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F91AA19F3299E006F6675 /* SharedExamplesTests.swift */; };
+		1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 4728253A1A5EECCE008DC74F /* SharedExamplesTests+ObjC.m */; };
+		1F118D221BDCA556005013A2 /* SharedExamples+BeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB0136E19FC4315006AFBEE /* SharedExamples+BeforeEachTests.swift */; };
+		1F118D231BDCA556005013A2 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 4748E8931A6AEBB3009EC992 /* SharedExamples+BeforeEachTests+ObjC.m */; };
+		1F118D241BDCA561005013A2 /* FocusedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9876BF1A4C87200004AA17 /* FocusedTests.swift */; };
+		1F118D251BDCA561005013A2 /* FocusedTests+ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF28BC21A4DB8EC00A5D9BF /* FocusedTests+ObjC.m */; };
+		1F118D261BDCA5AF005013A2 /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED1EC81B110699006F61EC /* World+DSL.h */; };
+		1F118D271BDCA5AF005013A2 /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED1EC21B1105BC006F61EC /* World.h */; };
+		1F118D281BDCA5AF005013A2 /* NSString+QCKSelectorName.h in Headers */ = {isa = PBXBuildFile; fileRef = 34F375A019515CA700CE1B99 /* NSString+QCKSelectorName.h */; };
+		1F118D291BDCA5B6005013A2 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE714FC19FF6A62005905B8 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F118D2A1BDCA5B6005013A2 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = DA3124E319FCAEE8002858A7 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F118D2B1BDCA5B6005013A2 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = DAEB6B931943873100289F44 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F118D2C1BDCA5B6005013A2 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 34F375A419515CA700CE1B99 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F118D351BDCA657005013A2 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118D341BDCA657005013A2 /* Nimble.framework */; };
+		1F118D371BDCA65C005013A2 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F118D361BDCA65C005013A2 /* Nimble.framework */; };
+		1F118D381BDCA6E1005013A2 /* Configuration+BeforeEachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE714EF19FF65D3005905B8 /* Configuration+BeforeEachTests.swift */; };
+		1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE714F219FF65E7005905B8 /* Configuration+BeforeEach.swift */; };
 		1FD0CFAD1AFA0B8C00874CC1 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8100E901A1E4447007595ED /* Nimble.framework */; };
 		34F375A719515CA700CE1B99 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F3759C19515CA700CE1B99 /* Callsite.swift */; };
 		34F375A819515CA700CE1B99 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F3759C19515CA700CE1B99 /* Callsite.swift */; };
@@ -253,6 +308,20 @@
 			remoteGlobalIDString = DAEB6B8D1943873100289F44;
 			remoteInfo = Quick;
 		};
+		1F118CE01BDCA4AB005013A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DAEB6B851943873100289F44 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F118CD41BDCA4AB005013A2;
+			remoteInfo = "Quick-tvOS";
+		};
+		1F118CF61BDCA4BB005013A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DAEB6B851943873100289F44 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F118CD41BDCA4AB005013A2;
+			remoteInfo = "Quick-tvOS";
+		};
 		5A5D118819473F2100F6D13D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DAEB6B851943873100289F44 /* Project object */;
@@ -305,6 +374,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F118CD51BDCA4AB005013A2 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F118CDE1BDCA4AB005013A2 /* Quick-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quick-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F118CF01BDCA4BB005013A2 /* QuickFocused-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "QuickFocused-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F118D341BDCA657005013A2 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Externals/Nimble/build/Debug-appletvos/Nimble.framework"; sourceTree = "<group>"; };
+		1F118D361BDCA65C005013A2 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Externals/Nimble/build/Debug-appletvos/Nimble.framework"; sourceTree = "<group>"; };
 		34F3759C19515CA700CE1B99 /* Callsite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Callsite.swift; sourceTree = "<group>"; };
 		34F3759E19515CA700CE1B99 /* Example.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Example.swift; sourceTree = "<group>"; };
 		34F3759F19515CA700CE1B99 /* ExampleGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleGroup.swift; sourceTree = "<group>"; };
@@ -371,6 +445,31 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1F118CD11BDCA4AB005013A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F118CDB1BDCA4AB005013A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F118CDF1BDCA4AB005013A2 /* Quick.framework in Frameworks */,
+				1F118D351BDCA657005013A2 /* Nimble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F118CED1BDCA4BB005013A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F118CF51BDCA4BB005013A2 /* Quick.framework in Frameworks */,
+				1F118D371BDCA65C005013A2 /* Nimble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5A5D117819473F2100F6D13D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -424,6 +523,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F118D331BDCA645005013A2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1F118D361BDCA65C005013A2 /* Nimble.framework */,
+				1F118D341BDCA657005013A2 /* Nimble.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DA169E4619FF5DF100619816 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
@@ -545,6 +653,7 @@
 				DAEB6B9D1943873100289F44 /* QuickTests */,
 				DA9876BE1A4C87200004AA17 /* QuickFocusedTests */,
 				DAEB6B8F1943873100289F44 /* Products */,
+				1F118D331BDCA645005013A2 /* Frameworks */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -559,6 +668,9 @@
 				5A5D118619473F2100F6D13D /* Quick-iOSTests.xctest */,
 				DA9876B21A4C70EB0004AA17 /* QuickFocused-iOSTests.xctest */,
 				DA5663E81A4C8D8500193C88 /* QuickFocused-OSXTests.xctest */,
+				1F118CD51BDCA4AB005013A2 /* Quick.framework */,
+				1F118CDE1BDCA4AB005013A2 /* Quick-tvOSTests.xctest */,
+				1F118CF01BDCA4BB005013A2 /* QuickFocused-tvOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -634,6 +746,20 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1F118CD21BDCA4AB005013A2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F118D2B1BDCA5B6005013A2 /* Quick.h in Headers */,
+				1F118D261BDCA5AF005013A2 /* World+DSL.h in Headers */,
+				1F118D271BDCA5AF005013A2 /* World.h in Headers */,
+				1F118D2A1BDCA5B6005013A2 /* QCKDSL.h in Headers */,
+				1F118D2C1BDCA5B6005013A2 /* QuickSpec.h in Headers */,
+				1F118D281BDCA5AF005013A2 /* NSString+QCKSelectorName.h in Headers */,
+				1F118D291BDCA5B6005013A2 /* QuickConfiguration.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5A5D117919473F2100F6D13D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -665,6 +791,60 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1F118CD41BDCA4AB005013A2 /* Quick-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F118CE61BDCA4AB005013A2 /* Build configuration list for PBXNativeTarget "Quick-tvOS" */;
+			buildPhases = (
+				1F118CD01BDCA4AB005013A2 /* Sources */,
+				1F118CD11BDCA4AB005013A2 /* Frameworks */,
+				1F118CD21BDCA4AB005013A2 /* Headers */,
+				1F118CD31BDCA4AB005013A2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Quick-tvOS";
+			productName = "Quick-tvOS";
+			productReference = 1F118CD51BDCA4AB005013A2 /* Quick.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F118CDD1BDCA4AB005013A2 /* Quick-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F118CE91BDCA4AB005013A2 /* Build configuration list for PBXNativeTarget "Quick-tvOSTests" */;
+			buildPhases = (
+				1F118CDA1BDCA4AB005013A2 /* Sources */,
+				1F118CDB1BDCA4AB005013A2 /* Frameworks */,
+				1F118CDC1BDCA4AB005013A2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1F118CE11BDCA4AB005013A2 /* PBXTargetDependency */,
+			);
+			name = "Quick-tvOSTests";
+			productName = "Quick-tvOSTests";
+			productReference = 1F118CDE1BDCA4AB005013A2 /* Quick-tvOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		1F118CEF1BDCA4BB005013A2 /* QuickFocused-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F118CF81BDCA4BC005013A2 /* Build configuration list for PBXNativeTarget "QuickFocused-tvOSTests" */;
+			buildPhases = (
+				1F118CEC1BDCA4BB005013A2 /* Sources */,
+				1F118CED1BDCA4BB005013A2 /* Frameworks */,
+				1F118CEE1BDCA4BB005013A2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1F118CF71BDCA4BB005013A2 /* PBXTargetDependency */,
+			);
+			name = "QuickFocused-tvOSTests";
+			productName = "QuickFocused-tvOSTests";
+			productReference = 1F118CF01BDCA4BB005013A2 /* QuickFocused-tvOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		5A5D117B19473F2100F6D13D /* Quick-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5A5D119319473F2100F6D13D /* Build configuration list for PBXNativeTarget "Quick-iOS" */;
@@ -801,10 +981,19 @@
 		DAEB6B851943873100289F44 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Brian Ivan Gesiak";
 				TargetAttributes = {
+					1F118CD41BDCA4AB005013A2 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+					1F118CDD1BDCA4AB005013A2 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+					1F118CEF1BDCA4BB005013A2 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 					5A5D117B19473F2100F6D13D = {
 						CreatedOnToolsVersion = 6.0;
 					};
@@ -845,11 +1034,35 @@
 				5A5D117B19473F2100F6D13D /* Quick-iOS */,
 				5A5D118519473F2100F6D13D /* Quick-iOSTests */,
 				DA9876B11A4C70EB0004AA17 /* QuickFocused-iOSTests */,
+				1F118CD41BDCA4AB005013A2 /* Quick-tvOS */,
+				1F118CDD1BDCA4AB005013A2 /* Quick-tvOSTests */,
+				1F118CEF1BDCA4BB005013A2 /* QuickFocused-tvOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F118CD31BDCA4AB005013A2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F118CDC1BDCA4AB005013A2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F118CEE1BDCA4BB005013A2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5A5D117A19473F2100F6D13D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -895,6 +1108,71 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1F118CD01BDCA4AB005013A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F118D031BDCA536005013A2 /* World.swift in Sources */,
+				1F118CFC1BDCA536005013A2 /* Configuration.swift in Sources */,
+				1F118D021BDCA536005013A2 /* SuiteHooks.swift in Sources */,
+				1F118CFB1BDCA536005013A2 /* QuickConfiguration.m in Sources */,
+				1F118D041BDCA536005013A2 /* Example.swift in Sources */,
+				1F118CFF1BDCA536005013A2 /* QCKDSL.m in Sources */,
+				1F118D071BDCA536005013A2 /* Callsite.swift in Sources */,
+				1F118D081BDCA536005013A2 /* Filter.swift in Sources */,
+				1F118CFD1BDCA536005013A2 /* World+DSL.swift in Sources */,
+				1F118D0A1BDCA536005013A2 /* NSString+QCKSelectorName.m in Sources */,
+				1F118CFE1BDCA536005013A2 /* DSL.swift in Sources */,
+				1F118D001BDCA536005013A2 /* Closures.swift in Sources */,
+				1F118D051BDCA536005013A2 /* ExampleMetadata.swift in Sources */,
+				1F118D061BDCA536005013A2 /* ExampleGroup.swift in Sources */,
+				1F118D091BDCA536005013A2 /* QuickSpec.m in Sources */,
+				1F118D011BDCA536005013A2 /* ExampleHooks.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F118CDA1BDCA4AB005013A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F118D381BDCA6E1005013A2 /* Configuration+BeforeEachTests.swift in Sources */,
+				1F118D121BDCA556005013A2 /* ItTests.swift in Sources */,
+				1F118D1C1BDCA556005013A2 /* BeforeSuiteTests.swift in Sources */,
+				1F118D1D1BDCA556005013A2 /* BeforeSuiteTests+ObjC.m in Sources */,
+				1F118D0E1BDCA547005013A2 /* QCKSpecRunner.m in Sources */,
+				1F118D141BDCA556005013A2 /* FailureTests+ObjC.m in Sources */,
+				1F118D0F1BDCA54B005013A2 /* FunctionalTests_SharedExamplesTests_SharedExamples.swift in Sources */,
+				1F118D101BDCA556005013A2 /* Configuration+AfterEach.swift in Sources */,
+				1F118D1F1BDCA556005013A2 /* AfterSuiteTests+ObjC.m in Sources */,
+				1F118D1A1BDCA556005013A2 /* PendingTests.swift in Sources */,
+				1F118D171BDCA556005013A2 /* BeforeEachTests+ObjC.m in Sources */,
+				1F118D231BDCA556005013A2 /* SharedExamples+BeforeEachTests+ObjC.m in Sources */,
+				1F118D151BDCA556005013A2 /* FailureUsingXCTAssertTests+ObjC.m in Sources */,
+				1F118D131BDCA556005013A2 /* ItTests+ObjC.m in Sources */,
+				1F118D191BDCA556005013A2 /* AfterEachTests+ObjC.m in Sources */,
+				1F118D221BDCA556005013A2 /* SharedExamples+BeforeEachTests.swift in Sources */,
+				1F118D211BDCA556005013A2 /* SharedExamplesTests+ObjC.m in Sources */,
+				1F118D201BDCA556005013A2 /* SharedExamplesTests.swift in Sources */,
+				1F118D0C1BDCA543005013A2 /* QuickConfigurationTests.m in Sources */,
+				1F118D391BDCA6E6005013A2 /* Configuration+BeforeEach.swift in Sources */,
+				1F118D181BDCA556005013A2 /* AfterEachTests.swift in Sources */,
+				1F118D1B1BDCA556005013A2 /* PendingTests+ObjC.m in Sources */,
+				1F118D1E1BDCA556005013A2 /* AfterSuiteTests.swift in Sources */,
+				1F118D111BDCA556005013A2 /* Configuration+AfterEachTests.swift in Sources */,
+				1F118D161BDCA556005013A2 /* BeforeEachTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F118CEC1BDCA4BB005013A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F118D0D1BDCA547005013A2 /* QCKSpecRunner.m in Sources */,
+				1F118D241BDCA561005013A2 /* FocusedTests.swift in Sources */,
+				1F118D251BDCA561005013A2 /* FocusedTests+ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5A5D117719473F2100F6D13D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1123,6 +1401,16 @@
 			target = DAEB6B8D1943873100289F44 /* Quick-OSX */;
 			targetProxy = 04DC9808194B838B00CE00B6 /* PBXContainerItemProxy */;
 		};
+		1F118CE11BDCA4AB005013A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F118CD41BDCA4AB005013A2 /* Quick-tvOS */;
+			targetProxy = 1F118CE01BDCA4AB005013A2 /* PBXContainerItemProxy */;
+		};
+		1F118CF71BDCA4BB005013A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F118CD41BDCA4AB005013A2 /* Quick-tvOS */;
+			targetProxy = 1F118CF61BDCA4BB005013A2 /* PBXContainerItemProxy */;
+		};
 		5A5D118919473F2100F6D13D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5A5D117B19473F2100F6D13D /* Quick-iOS */;
@@ -1161,6 +1449,141 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1F118CE71BDCA4AB005013A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Quick/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Quick;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F118CE81BDCA4AB005013A2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Quick/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Quick;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1F118CEA1BDCA4AB005013A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Externals/Nimble/build/Debug-appletvos",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = QuickTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F118CEB1BDCA4AB005013A2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Externals/Nimble/build/Debug-appletvos",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = QuickTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1F118CF91BDCA4BC005013A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Externals/Nimble/build/Debug-appletvos",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = QuickFocusedTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1F118CFA1BDCA4BC005013A2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Externals/Nimble/build/Debug-appletvos",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = QuickFocusedTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.quick.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = QuickTests/Helpers/QuickTestsBridgingHeader.h;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		5A5D118F19473F2100F6D13D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1190,7 +1613,7 @@
 				PRODUCT_NAME = Quick;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1220,7 +1643,7 @@
 				PRODUCT_NAME = Quick;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -1540,6 +1963,33 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1F118CE61BDCA4AB005013A2 /* Build configuration list for PBXNativeTarget "Quick-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F118CE71BDCA4AB005013A2 /* Debug */,
+				1F118CE81BDCA4AB005013A2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F118CE91BDCA4AB005013A2 /* Build configuration list for PBXNativeTarget "Quick-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F118CEA1BDCA4AB005013A2 /* Debug */,
+				1F118CEB1BDCA4AB005013A2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F118CF81BDCA4BC005013A2 /* Build configuration list for PBXNativeTarget "QuickFocused-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F118CF91BDCA4BC005013A2 /* Debug */,
+				1F118CFA1BDCA4BC005013A2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		5A5D119319473F2100F6D13D /* Build configuration list for PBXNativeTarget "Quick-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Carthage/Checkouts/Quick/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
+++ b/Carthage/Checkouts/Quick/Quick.xcodeproj/xcshareddata/xcschemes/Quick-tvOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0710"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F1A74281940169200FFFC47"
-               BuildableName = "Nimble.framework"
-               BlueprintName = "Nimble-iOS"
-               ReferencedContainer = "container:Nimble.xcodeproj">
+               BlueprintIdentifier = "1F118CD41BDCA4AB005013A2"
+               BuildableName = "Quick.framework"
+               BlueprintName = "Quick-tvOS"
+               ReferencedContainer = "container:Quick.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -32,34 +32,52 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F1A74331940169200FFFC47"
-               BuildableName = "NimbleTests.xctest"
-               BlueprintName = "Nimble-iOSTests"
-               ReferencedContainer = "container:Nimble.xcodeproj">
+               BlueprintIdentifier = "1F118CDD1BDCA4AB005013A2"
+               BuildableName = "Quick-tvOSTests.xctest"
+               BlueprintName = "Quick-tvOSTests"
+               ReferencedContainer = "container:Quick.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1F118CEF1BDCA4BB005013A2"
+               BuildableName = "QuickFocused-tvOSTests.xctest"
+               BlueprintName = "QuickFocused-tvOSTests"
+               ReferencedContainer = "container:Quick.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F118CD41BDCA4AB005013A2"
+            BuildableName = "Quick.framework"
+            BlueprintName = "Quick-tvOS"
+            ReferencedContainer = "container:Quick.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      debugXPCServices = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1F1A74281940169200FFFC47"
-            BuildableName = "Nimble.framework"
-            BlueprintName = "Nimble-iOS"
-            ReferencedContainer = "container:Nimble.xcodeproj">
+            BlueprintIdentifier = "1F118CD41BDCA4AB005013A2"
+            BuildableName = "Quick.framework"
+            BlueprintName = "Quick-tvOS"
+            ReferencedContainer = "container:Quick.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
@@ -71,6 +89,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F118CD41BDCA4AB005013A2"
+            BuildableName = "Quick.framework"
+            BlueprintName = "Quick-tvOS"
+            ReferencedContainer = "container:Quick.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Carthage/Checkouts/Quick/Quick/Quick.h
+++ b/Carthage/Checkouts/Quick/Quick/Quick.h
@@ -6,8 +6,6 @@ FOUNDATION_EXPORT double QuickVersionNumber;
 //! Project version string for Quick.
 FOUNDATION_EXPORT const unsigned char QuickVersionString[];
 
-// In this header, you should import all the public headers of your framework using statements like #import <Quick/PublicHeader.h>
-
-#import <Quick/QuickSpec.h>
-#import <Quick/QCKDSL.h>
-#import <Quick/QuickConfiguration.h>
+#import "QuickSpec.h"
+#import "QCKDSL.h"
+#import "QuickConfiguration.h"

--- a/Carthage/Checkouts/Quick/script/release
+++ b/Carthage/Checkouts/Quick/script/release
@@ -80,7 +80,7 @@ fi
 if [ ! -f "$RELEASE_NOTES" ]; then
     echo " > Failed to find $RELEASE_NOTES. Prompting editor"
     RELEASE_NOTES=.release-changes
-    LATEST_TAG=`git for-each-ref refs/tags --sort=-refname --format="%(refname:short)" | grep 'v\\?\\d\\+\\.\\d\\+\\.\\d\\+' | ruby -e 'puts STDIN.read.split("\n").sort { |a,b| a.gsub("v", "").split(".").map(&:to_i) <=> b.gsub("v", "").split(".").map(&:to_i) }.last'`
+    LATEST_TAG=`git for-each-ref refs/tags --sort=-refname --format="%(refname:short)" | grep -E "^v\d+\.\d+\.\d+(-\w+(\.\d)?)?\$" | ruby -e 'puts STDIN.read.split("\n").sort { |a,b| Gem::Version.new(a.gsub(/^v/, "")) <=> Gem::Version.new(b.gsub(/^v/, "")) }.last'`
     echo " > Latest tag ${LATEST_TAG}"
     echo "${POD_NAME} v$VERSION" > $RELEASE_NOTES
     echo "================" >> $RELEASE_NOTES

--- a/Scenarios.xcodeproj/project.pbxproj
+++ b/Scenarios.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		CE6BE1631BDEC984009DC35F /* ScenarioBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */; };
 		CE6CDF881BE2DEBF00AE6393 /* Regex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6CDF871BE2DEBE00AE6393 /* Regex.framework */; };
 		CEB2985C1BDE030B00ACA986 /* ScenarioDescriptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */; };
+		CED2450B1BE2E357009E4F3B /* StepArgumentsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED245091BE2E329009E4F3B /* StepArgumentsFeature.swift */; };
+		CED2450D1BE2E658009E4F3B /* StepArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED2450C1BE2E658009E4F3B /* StepArguments.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,8 +47,10 @@
 		CE3AD7391BDF01A000A714D8 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE3AD73B1BDF01AC00A714D8 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioBuilder.swift; sourceTree = "<group>"; };
-		CE6CDF871BE2DEBE00AE6393 /* Regex.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Regex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE6CDF871BE2DEBE00AE6393 /* Regex.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Regex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioDescriptors.swift; sourceTree = "<group>"; };
+		CED245091BE2E329009E4F3B /* StepArgumentsFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StepArgumentsFeature.swift; sourceTree = "<group>"; };
+		CED2450C1BE2E658009E4F3B /* StepArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StepArguments.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +103,7 @@
 				CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */,
 				CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */,
 				CE0508A91BDDE78B00B21C8C /* Step.swift */,
+				CED2450C1BE2E658009E4F3B /* StepArguments.swift */,
 				CE0508AA1BDDE78B00B21C8C /* StepDefinition.swift */,
 				CE337CC01BDF1C2300BE8BFC /* Supporting Files */,
 			);
@@ -109,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				CE337CBD1BDF1C1000BE8BFC /* ScenarioSpec.swift */,
+				CED245091BE2E329009E4F3B /* StepArgumentsFeature.swift */,
 				CE337CBF1BDF1C1700BE8BFC /* Supporting Files */,
 			);
 			path = ScenariosTests;
@@ -254,6 +260,7 @@
 				CE0508AC1BDDE78B00B21C8C /* Scenario.swift in Sources */,
 				CE0508AD1BDDE78B00B21C8C /* Step.swift in Sources */,
 				CEB2985C1BDE030B00ACA986 /* ScenarioDescriptors.swift in Sources */,
+				CED2450D1BE2E658009E4F3B /* StepArguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE337CC11BDF1D1500BE8BFC /* ScenarioSpec.swift in Sources */,
+				CED2450B1BE2E357009E4F3B /* StepArgumentsFeature.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Scenarios.xcodeproj/project.pbxproj
+++ b/Scenarios.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		CE3AD73A1BDF01A000A714D8 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE3AD7391BDF01A000A714D8 /* Quick.framework */; };
 		CE3AD73C1BDF01AC00A714D8 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE3AD73B1BDF01AC00A714D8 /* Nimble.framework */; };
 		CE6BE1631BDEC984009DC35F /* ScenarioBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */; };
+		CE6CDF881BE2DEBF00AE6393 /* Regex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6CDF871BE2DEBE00AE6393 /* Regex.framework */; };
 		CEB2985C1BDE030B00ACA986 /* ScenarioDescriptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,6 +45,7 @@
 		CE3AD7391BDF01A000A714D8 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE3AD73B1BDF01AC00A714D8 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioBuilder.swift; sourceTree = "<group>"; };
+		CE6CDF871BE2DEBE00AE6393 /* Regex.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Regex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioDescriptors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -53,6 +55,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE3AD73A1BDF01A000A714D8 /* Quick.framework in Frameworks */,
+				CE6CDF881BE2DEBF00AE6393 /* Regex.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,6 +117,7 @@
 		CE0508B51BDDE94A00B21C8C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CE6CDF871BE2DEBE00AE6393 /* Regex.framework */,
 				CE3AD7391BDF01A000A714D8 /* Quick.framework */,
 				CE3AD73B1BDF01AC00A714D8 /* Nimble.framework */,
 			);

--- a/Scenarios.xcworkspace/contents.xcworkspacedata
+++ b/Scenarios.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,9 @@
       location = "container:Scenarios.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:Carthage/Checkouts/Regex/Regex.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:Carthage/Checkouts/Quick/Quick.xcodeproj">
    </FileRef>
    <FileRef

--- a/Scenarios/Scenario.swift
+++ b/Scenarios/Scenario.swift
@@ -81,7 +81,7 @@ private typealias StepMetadata = (description: String, file: String, line: UInt)
 
 private enum ResolvedSteps {
   case MissingStep(StepMetadata)
-  case MatchedActions([() -> ()])
+  case MatchedActions([StepActionFunc])
 }
 
 import Quick

--- a/Scenarios/StepArguments.swift
+++ b/Scenarios/StepArguments.swift
@@ -1,0 +1,20 @@
+//  Copyright © 2015 Outware Mobile. All rights reserved.
+
+public struct StepArguments: Indexable {
+
+  public let startIndex: Int = 0
+  public var endIndex: Int { return captures.endIndex }
+
+  private let captures: [String]
+
+  internal init(_ matchResult: MatchResult) {
+    self.captures = matchResult.captures
+  }
+
+  public subscript(index: Int) -> String {
+    return captures[index]
+  }
+
+}
+
+import Regex

--- a/ScenariosTests/StepArgumentsFeature.swift
+++ b/ScenariosTests/StepArgumentsFeature.swift
@@ -1,0 +1,67 @@
+//  Copyright © 2015 Outware Mobile. All rights reserved.
+
+final class StepArgumentsFeature: Feature {
+  override func scenarios() {
+
+    Scenario("Single argument")
+      .Given("I provide arguments [1:hello]")
+      .Then("the first argument is hello")
+
+    Scenario("Two arguments")
+      .Given("I provide arguments [1:hello 2:world]")
+      .Then("the first argument is hello")
+      .And("the second argument is world")
+
+    Scenario("Three arguments")
+      .Given("I provide arguments [1:foo 2:bar 3:baz]")
+      .Then("the first argument is foo")
+      .And("the second argument is bar")
+      .And("the third argument is baz")
+
+  }
+}
+
+final class StepArgumentsSteps: StepDefinition {
+  override func steps() {
+
+    var capturedArgs: StepArguments!
+
+    Given("I provide arguments \\[1:(\\S+)\\]") { args in
+      capturedArgs = args
+    }
+
+    Given("I provide arguments \\[1:(\\S+) 2:(\\S+)\\]") { args in
+      capturedArgs = args
+    }
+
+    Given("I provide arguments \\[1:(\\S+) 2:(\\S+) 3:(\\S+)\\]") { args in
+      capturedArgs = args
+    }
+
+    Then("the (.+) argument is (.+)") { args in
+      let (position, subject) = (args[0], args[1])
+
+      let expected: String
+
+      switch position {
+      case "first":
+        expected = capturedArgs[0]
+      case "second":
+        expected = capturedArgs[1]
+      case "third":
+        expected = capturedArgs[2]
+      case "fourth":
+        expected = capturedArgs[3]
+      default:
+        fail("couldn't find an argument at position \(position)")
+        return
+      }
+
+      expect(subject).to(equal(expected))
+    }
+
+  }
+}
+
+import Nimble
+import Scenarios


### PR DESCRIPTION
:sparkles:

Currently the step lookup algorithm just enumerates all available step
definitions until it finds a match. This isn't particularly optimised,
but appears to be how it's implemented in cucumber-ruby.

It also doesn't handle ambiguity (multiple step definitions matching a
step name), but that can be saved for another day.

Fixes #6.
