### PR TITLE
Update dependency setup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 install:
   - brew update && brew uninstall --force carthage && brew install carthage
   - gem install xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode7.2
 install:
-  - brew update && brew install carthage
+  - brew update && brew uninstall --force carthage && brew install carthage
   - gem install xcpretty
 before_script: carthage bootstrap --platform iphoneos
 script: rake


### PR DESCRIPTION
Making sure Carthage is uninstalled fully before a fresh install attempt.

This is to fix the failure to re-install to the latest version when Carthage is installed and is few version behind.
