### PR TITLE
Tidy up

### DIFF
--- a/Scenarios.xcodeproj/project.pbxproj
+++ b/Scenarios.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4A43F55C1ED7DC3400BE4A6D /* Roles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A43F55B1ED7DC3400BE4A6D /* Roles.swift */; };
+		4A43F55E1ED7DD8300BE4A6D /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A43F55D1ED7DD8300BE4A6D /* Types.swift */; };
 		CE0508911BDDE75100B21C8C /* Scenarios.h in Headers */ = {isa = PBXBuildFile; fileRef = CE0508901BDDE75100B21C8C /* Scenarios.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE0508981BDDE75100B21C8C /* Scenarios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE05088D1BDDE75100B21C8C /* Scenarios.framework */; };
 		CE0508AB1BDDE78B00B21C8C /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0508A71BDDE78B00B21C8C /* Feature.swift */; };
@@ -22,7 +23,6 @@
 		CE8C773A1C040B7700C2EA7E /* Nimble.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE8C77311C040B2E00C2EA7E /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE8C773B1C040B7700C2EA7E /* Quick.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE8C77321C040B2E00C2EA7E /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE8C773C1C040B7700C2EA7E /* Regex.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE8C77331C040B2E00C2EA7E /* Regex.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		CEB2985C1BDE030B00ACA986 /* ScenarioDescriptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */; };
 		CED2450B1BE2E357009E4F3B /* StepArgumentsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED245091BE2E329009E4F3B /* StepArgumentsFeature.swift */; };
 		CED2450D1BE2E658009E4F3B /* StepArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED2450C1BE2E658009E4F3B /* StepArguments.swift */; };
 /* End PBXBuildFile section */
@@ -55,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		4A43F55B1ED7DC3400BE4A6D /* Roles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Roles.swift; sourceTree = "<group>"; };
+		4A43F55D1ED7DD8300BE4A6D /* Types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
 		CE05088D1BDDE75100B21C8C /* Scenarios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Scenarios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE0508901BDDE75100B21C8C /* Scenarios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Scenarios.h; sourceTree = "<group>"; };
 		CE0508921BDDE75100B21C8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -68,7 +69,6 @@
 		CE8C77311C040B2E00C2EA7E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		CE8C77321C040B2E00C2EA7E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		CE8C77331C040B2E00C2EA7E /* Regex.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Regex.framework; path = Carthage/Build/iOS/Regex.framework; sourceTree = "<group>"; };
-		CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioDescriptors.swift; sourceTree = "<group>"; };
 		CED245091BE2E329009E4F3B /* StepArgumentsFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StepArgumentsFeature.swift; sourceTree = "<group>"; };
 		CED2450C1BE2E658009E4F3B /* StepArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StepArguments.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -100,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				4A43F55B1ED7DC3400BE4A6D /* Roles.swift */,
+				4A43F55D1ED7DD8300BE4A6D /* Types.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -129,7 +130,6 @@
 				CE0508901BDDE75100B21C8C /* Scenarios.h */,
 				CE0508A71BDDE78B00B21C8C /* Feature.swift */,
 				CE0508A81BDDE78B00B21C8C /* Scenario.swift */,
-				CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */,
 				CE0508A91BDDE78B00B21C8C /* Step.swift */,
 				CED2450C1BE2E658009E4F3B /* StepArguments.swift */,
 				CE0508AA1BDDE78B00B21C8C /* StepDefinition.swift */,
@@ -289,9 +289,9 @@
 				CE0508AE1BDDE78B00B21C8C /* StepDefinition.swift in Sources */,
 				CE0508AB1BDDE78B00B21C8C /* Feature.swift in Sources */,
 				4A43F55C1ED7DC3400BE4A6D /* Roles.swift in Sources */,
+				4A43F55E1ED7DD8300BE4A6D /* Types.swift in Sources */,
 				CE0508AC1BDDE78B00B21C8C /* Scenario.swift in Sources */,
 				CE0508AD1BDDE78B00B21C8C /* Step.swift in Sources */,
-				CEB2985C1BDE030B00ACA986 /* ScenarioDescriptors.swift in Sources */,
 				CED2450D1BE2E658009E4F3B /* StepArguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Scenarios.xcodeproj/project.pbxproj
+++ b/Scenarios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A43F55C1ED7DC3400BE4A6D /* Roles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A43F55B1ED7DC3400BE4A6D /* Roles.swift */; };
 		CE0508911BDDE75100B21C8C /* Scenarios.h in Headers */ = {isa = PBXBuildFile; fileRef = CE0508901BDDE75100B21C8C /* Scenarios.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE0508981BDDE75100B21C8C /* Scenarios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE05088D1BDDE75100B21C8C /* Scenarios.framework */; };
 		CE0508AB1BDDE78B00B21C8C /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0508A71BDDE78B00B21C8C /* Feature.swift */; };
@@ -14,7 +15,6 @@
 		CE0508AD1BDDE78B00B21C8C /* Step.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0508A91BDDE78B00B21C8C /* Step.swift */; };
 		CE0508AE1BDDE78B00B21C8C /* StepDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0508AA1BDDE78B00B21C8C /* StepDefinition.swift */; };
 		CE337CC11BDF1D1500BE8BFC /* ScenarioSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE337CBD1BDF1C1000BE8BFC /* ScenarioSpec.swift */; };
-		CE6BE1631BDEC984009DC35F /* ScenarioBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */; };
 		CE8C77351C040B2E00C2EA7E /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8C77321C040B2E00C2EA7E /* Quick.framework */; };
 		CE8C77361C040B2E00C2EA7E /* Regex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8C77331C040B2E00C2EA7E /* Regex.framework */; };
 		CE8C77371C040B5700C2EA7E /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8C77311C040B2E00C2EA7E /* Nimble.framework */; };
@@ -54,6 +54,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4A43F55B1ED7DC3400BE4A6D /* Roles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Roles.swift; sourceTree = "<group>"; };
 		CE05088D1BDDE75100B21C8C /* Scenarios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Scenarios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE0508901BDDE75100B21C8C /* Scenarios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Scenarios.h; sourceTree = "<group>"; };
 		CE0508921BDDE75100B21C8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -64,7 +65,6 @@
 		CE0508A91BDDE78B00B21C8C /* Step.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Step.swift; sourceTree = "<group>"; };
 		CE0508AA1BDDE78B00B21C8C /* StepDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StepDefinition.swift; sourceTree = "<group>"; };
 		CE337CBD1BDF1C1000BE8BFC /* ScenarioSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioSpec.swift; sourceTree = "<group>"; };
-		CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioBuilder.swift; sourceTree = "<group>"; };
 		CE8C77311C040B2E00C2EA7E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		CE8C77321C040B2E00C2EA7E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		CE8C77331C040B2E00C2EA7E /* Regex.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Regex.framework; path = Carthage/Build/iOS/Regex.framework; sourceTree = "<group>"; };
@@ -96,6 +96,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4A43F55A1ED7DC1300BE4A6D /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				4A43F55B1ED7DC3400BE4A6D /* Roles.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		CE0508831BDDE75100B21C8C = {
 			isa = PBXGroup;
 			children = (
@@ -121,11 +129,11 @@
 				CE0508901BDDE75100B21C8C /* Scenarios.h */,
 				CE0508A71BDDE78B00B21C8C /* Feature.swift */,
 				CE0508A81BDDE78B00B21C8C /* Scenario.swift */,
-				CE6BE1621BDEC984009DC35F /* ScenarioBuilder.swift */,
 				CEB2985B1BDE030B00ACA986 /* ScenarioDescriptors.swift */,
 				CE0508A91BDDE78B00B21C8C /* Step.swift */,
 				CED2450C1BE2E658009E4F3B /* StepArguments.swift */,
 				CE0508AA1BDDE78B00B21C8C /* StepDefinition.swift */,
+				4A43F55A1ED7DC1300BE4A6D /* Components */,
 				CE337CC01BDF1C2300BE8BFC /* Supporting Files */,
 			);
 			path = Scenarios;
@@ -279,8 +287,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE0508AE1BDDE78B00B21C8C /* StepDefinition.swift in Sources */,
-				CE6BE1631BDEC984009DC35F /* ScenarioBuilder.swift in Sources */,
 				CE0508AB1BDDE78B00B21C8C /* Feature.swift in Sources */,
+				4A43F55C1ED7DC3400BE4A6D /* Roles.swift in Sources */,
 				CE0508AC1BDDE78B00B21C8C /* Scenario.swift in Sources */,
 				CE0508AD1BDDE78B00B21C8C /* Step.swift in Sources */,
 				CEB2985C1BDE030B00ACA986 /* ScenarioDescriptors.swift in Sources */,

--- a/Scenarios/Components/Roles.swift
+++ b/Scenarios/Components/Roles.swift
@@ -2,14 +2,20 @@
 
 /// Scenarios which are being built whose most recent declaration can be extended.
 ///
-/// e.g.
-/// - Arranging (Preparing):
-///     Arranging pre-conditions for scenarios can be extended by doing further setup.
-/// - Acting:
-///     Acting on scenarios can be extended by doing further manipulation of
-///     model objects / user interface, for example.
-/// - Asserting: 
-///     Asserting results for scenarios can be extended by asserting multiple results.
+/// For example:
+///
+/// ## Arranging (Preparing):
+/// 
+/// Arranging pre-conditions for scenarios can be extended by doing further setup.
+/// 
+/// ## Acting:
+///
+/// Acting on scenarios can be extended by doing further manipulation of
+/// model objects / user interface, for example.
+///
+/// ## Asserting:
+///
+/// Asserting results for scenarios can be extended by asserting multiple results.
 public protocol Extendable {
 
   /// Specifies an extension to the most recent declaration of the scenario.

--- a/Scenarios/Components/Roles.swift
+++ b/Scenarios/Components/Roles.swift
@@ -74,9 +74,9 @@ public protocol Assertable {
 }
 
 
-/// Instances of conforming types are able to build scenarios by collecting multiple
+/// Instances of conforming types build scenarios by collecting multiple
 /// components (types which are `Preparable`, `Actionable`, `Assertable`) as they are
-/// built-up, and commiting the result to the test harness.
+/// built-up, and commit the result to the test harness.
 internal protocol ScenarioBuilder {
 
   /// Adds a specification to the scenario to-be-built.

--- a/Scenarios/Components/Roles.swift
+++ b/Scenarios/Components/Roles.swift
@@ -1,31 +1,91 @@
 //  Copyright © 2017 Outware Mobile. All rights reserved.
 
+/// Scenarios which are being built whose most recent declaration can be extended.
+///
+/// e.g.
+/// - Arranging (Preparing):
+///     Arranging pre-conditions for scenarios can be extended by doing further setup.
+/// - Acting:
+///     Acting on scenarios can be extended by doing further manipulation of
+///     model objects / user interface, for example.
+/// - Asserting: 
+///     Asserting results for scenarios can be extended by asserting multiple results.
 public protocol Extendable {
 
+  /// Specifies an extension to the most recent declaration of the scenario.
+  ///
+  /// - parameters:
+  ///     - description: The specification to add to the scenario.
+  ///
+  /// - returns: A scenario which captures all specifications in the previous scenario
+  ///            as well as the new specification.
   func And(_ description: String, file: String, line: UInt) -> Self
 
 }
 
+
+/// Scenarios which have yet to have any specification as to how they should be
+/// prepared / how the conditions for the scenario should be __arranged__.
 public protocol Preparable {
 
+  /// Specifies the preparation / arrangement step for the scenario.
+  ///
+  /// - parameters:
+  ///     - description: A specification detailing how the scenario should be prepared.
+  ///
+  /// - returns: A scenario which has had some preparation / arranging done.
+  ///
+  /// - seealso: Extendable
   func Given(_ description: String, file: String, line: UInt) -> Prepared
 
 }
 
+
+/// Scenarios for which the steps to carry out the tests which they capture have not
+/// yet been specified.
 public protocol Actionable {
 
+  /// Specifies the action step for the scenario.
+  ///
+  /// - parameters:
+  ///     - description: A specification detailing how the scenario should be acted upon.
+  ///
+  /// - returns: A scenario which has had some action performed.
+  ///
+  /// - seealso: Extendable
   func When(_ description: String, file: String, line: UInt) -> Actioned
 
 }
 
+
+/// Scenarios which have had some action / manipulation performed, and are ready to have
+/// results be asserted.
 public protocol Assertable {
 
+  /// Specifies the assertion step for the scenario.
+  ///
+  /// - parameters:
+  ///     - description: A specification detailing how the scenario's should have its
+  ///                    state be confirmed.
+  ///
+  /// - seealso: Extendable
   func Then(_ description: String, file: String, line: UInt) -> Asserted
   
 }
 
+
+/// Instances of conforming types are able to build scenarios by collecting multiple
+/// components (types which are `Preparable`, `Actionable`, `Assertable`) as they are
+/// built-up, and commiting the result to the test harness.
 internal protocol ScenarioBuilder {
 
+  /// Adds a specification to the scenario to-be-built.
+  ///
+  /// - note: Agnostic to the current stage of the built-up scenario.
+  ///
+  /// - parameters:
+  ///     - description: A specification detailing the steps to be appended to the
+  ///                    current state of the scenario.
   mutating func add(stepWithDescription description: String, file: String, line: UInt)
 
 }

--- a/Scenarios/Components/Roles.swift
+++ b/Scenarios/Components/Roles.swift
@@ -1,0 +1,31 @@
+//  Copyright © 2017 Outware Mobile. All rights reserved.
+
+public protocol Extendable {
+
+  func And(_ description: String, file: String, line: UInt) -> Self
+
+}
+
+public protocol Preparable {
+
+  func Given(_ description: String, file: String, line: UInt) -> Prepared
+
+}
+
+public protocol Actionable {
+
+  func When(_ description: String, file: String, line: UInt) -> Actioned
+
+}
+
+public protocol Assertable {
+
+  func Then(_ description: String, file: String, line: UInt) -> Asserted
+  
+}
+
+internal protocol ScenarioBuilder {
+
+  mutating func add(stepWithDescription description: String, file: String, line: UInt)
+
+}

--- a/Scenarios/Components/Types.swift
+++ b/Scenarios/Components/Types.swift
@@ -46,6 +46,26 @@ public final class Prepared: Assertable, Actionable, Extendable {
 
 }
 
+
+/// A scenario that has had some intermediate action(s) performed (it has had preconditions
+/// prepared, and its test steps, the actions, performed), and is ready to have its
+/// state be asserted.
+///
+/// - note: A scenario is generally `Actioned` as a result of a `When` step, followed
+///         by zero or more `And` steps.
+///
+/// e.g.
+///
+/// - __Given__ the user is on the Home Screen
+/// - __When__ the user taps the 'Edit' Button
+/// - ...
+///
+/// This scenario performs steps to take the user to the home screen as part of its
+/// 'arrange' steps (setting up its preconditions). It then performs the intermediate
+/// action(s) which is being tested (in this case, tapping on the edit button).
+///
+/// At this stage, the scenario has had its test case `Actioned`, and is ready to 
+/// have its (new) state be asserted.
 public final class Actioned: Assertable, Extendable {
 
   private var builder: ScenarioBuilder

--- a/Scenarios/Components/Types.swift
+++ b/Scenarios/Components/Types.swift
@@ -1,8 +1,8 @@
 //  Copyright © 2017 Outware Mobile. All rights reserved.
 
-/// A scenario that has had its preconditions prepared, and is ready to have its
-/// state acted upon, or to have state that is a result of preparing its _preconditions_
-/// asserted.
+/// A scenario that has had its preconditions prepared and is ready to:
+/// - have its state acted upon, or
+/// - have its prepared state asserted.
 ///
 /// - note: A scenario is generally `Prepared` as a result of a `Given` step, followed
 ///         by zero or more `And` steps.
@@ -17,7 +17,7 @@
 /// setup information such that their logged-in account is a "Type A" account.
 ///
 /// At this stage, the scenario is `Prepared` to:
-/// - have some state on the screen (such as the title of the screen) be asserted.
+/// - have some state on the screen (such as the title of the screen) be asserted, or
 /// - be manipulated / acted upon (for example, by tapping on a button, or scrolling down
 ///     a list), in preparation for future state assertion.
 public final class Prepared: Assertable, Actionable, Extendable {

--- a/Scenarios/Components/Types.swift
+++ b/Scenarios/Components/Types.swift
@@ -87,6 +87,33 @@ public final class Actioned: Assertable, Extendable {
 
 }
 
+
+/// A scenario that has had its state, post-test-case-execution, asserted.
+///
+/// - note: A scenario is generally `Asserted` as a result of a `Then` step, followed
+///         by zero or more `And` steps.
+///
+/// e.g.
+///
+/// - __Given__ the user is on the Home Screen
+/// - __When__ the user taps the 'Edit' Button
+/// - __Then__ the user is taken to the Edit Items Screen
+///
+/// This scenario performs steps to take the user to the home screen as part of its
+/// 'arrange' steps (setting up its preconditions). It then performs the intermediate
+/// action(s) which is being tested (in this case, tapping on the edit button). Finally,
+/// it 'assert's that the user is taken to the Edit Items screen (the semantics of
+/// determining that is up to the implementers).
+///
+/// - __Given__ the user is on the Home Screen
+/// - __Then__ the title of the screen is 'Home'
+///
+/// Similarly, this scenario performs steps to take the user to the home screen, if it
+/// is not the default screen displayed. It then 'assert's that the title of the screen
+/// is "Home".
+///
+/// At this stage, the scenario has `Asserted` its expectations of the results of
+/// the test case execution and is ready to be built.
 public final class Asserted: Extendable {
 
   private var builder: ScenarioBuilder

--- a/Scenarios/Components/Types.swift
+++ b/Scenarios/Components/Types.swift
@@ -1,5 +1,25 @@
 //  Copyright © 2017 Outware Mobile. All rights reserved.
 
+/// A scenario that has had its preconditions prepared, and is ready to have its
+/// state acted upon, or to have state that is a result of preparing its _preconditions_
+/// asserted.
+///
+/// - note: A scenario is generally `Prepared` as a result of a `Given` step, followed
+///         by zero or more `And` steps.
+///
+/// e.g.
+///
+/// - __Given__ the user is on the Home Screen
+/// - __And__ the currently logged-in account is a Type A account
+/// - ...
+///
+/// This scenario performs steps to take the user to the home screen and manipulates
+/// setup information such that their logged-in account is a "Type A" account.
+///
+/// At this stage, the scenario is `Prepared` to:
+/// - have some state on the screen (such as the title of the screen) be asserted.
+/// - be manipulated / acted upon (for example, by tapping on a button, or scrolling down
+///     a list), in preparation for future state assertion.
 public final class Prepared: Assertable, Actionable, Extendable {
 
   private var builder: ScenarioBuilder

--- a/Scenarios/Components/Types.swift
+++ b/Scenarios/Components/Types.swift
@@ -1,6 +1,4 @@
-//  Copyright © 2015 Outware Mobile. All rights reserved.
-
-// MARK: Types
+//  Copyright © 2017 Outware Mobile. All rights reserved.
 
 public final class Prepared: Assertable, Actionable, Extendable {
 

--- a/Scenarios/Feature.swift
+++ b/Scenarios/Feature.swift
@@ -3,6 +3,7 @@
 /// Subclass `Feature` and override `scenarios()` to define the steps for the
 /// scenarios in your feature.
 open class Feature: QuickSpec {
+
   override open func setUp() {
     super.setUp()
     continueAfterFailure = false
@@ -21,6 +22,7 @@ open class Feature: QuickSpec {
       super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
     }
   }
+
 }
 
 import Quick

--- a/Scenarios/Scenario.swift
+++ b/Scenarios/Scenario.swift
@@ -25,12 +25,12 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
   }
 
   public func Given(_ description: String, file: String = #file, line: UInt = #line) -> Prepared {
-    addStep(description, file: file, line: line)
+    add(stepWithDescription: description, file: file, line: line)
     return Prepared(self)
   }
 
   public func When(_ description: String, file: String = #file, line: UInt = #line) -> Actioned {
-    addStep(description, file: file, line: line)
+    add(stepWithDescription: description, file: file, line: line)
     return Actioned(self)
   }
 
@@ -70,7 +70,7 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
     commitFunc(description, file, line, closure)
   }
 
-  internal func addStep(_ description: String, file: String, line: UInt) {
+  internal func add(stepWithDescription description: String, file: String, line: UInt) {
     stepDescriptions.append(description: description, file: file, line: line)
   }
 

--- a/Scenarios/Scenario.swift
+++ b/Scenarios/Scenario.swift
@@ -10,6 +10,7 @@
 /// block by looking up the step definitions based on the step names. The test
 /// fails if any of the steps are undefined.
 public final class Scenario: Preparable, Actionable {
+
   fileprivate let name: String
   fileprivate let file: String
   fileprivate let line: UInt
@@ -68,6 +69,7 @@ public final class Scenario: Preparable, Actionable {
   fileprivate func commit(_ description: String, file: String, line: UInt, closure: @escaping () -> ()) {
     commitFunc(description, file, line, closure)
   }
+
 }
 
 public typealias CommitFunc = (String, String, UInt, @escaping () -> ()) -> ()
@@ -77,16 +79,20 @@ private let quick_it: CommitFunc = { description, file, line, closure in
 }
 
 extension Scenario: ScenarioBuilder {
+
   func addStep(_ description: String, file: String, line: UInt) {
     stepDescriptions.append(description: description, file: file, line: line)
   }
+
 }
 
 private typealias StepMetadata = (description: String, file: String, line: UInt)
 
 private enum ResolvedSteps {
+
   case missingStep(StepMetadata)
   case matchedActions([StepActionFunc])
+
 }
 
 import Quick

--- a/Scenarios/Scenario.swift
+++ b/Scenarios/Scenario.swift
@@ -9,13 +9,13 @@
 /// After the last step is defined, the scenario is compiled into a Quick example
 /// block by looking up the step definitions based on the step names. The test
 /// fails if any of the steps are undefined.
-public final class Scenario: Preparable, Actionable {
+public final class Scenario: Preparable, Actionable, ScenarioBuilder {
 
-  fileprivate let name: String
-  fileprivate let file: String
-  fileprivate let line: UInt
-  fileprivate let commitFunc: CommitFunc
-  fileprivate var stepDescriptions: [StepMetadata] = []
+  private let name: String
+  private let file: String
+  private let line: UInt
+  private let commitFunc: CommitFunc
+  private var stepDescriptions: [StepMetadata] = []
 
   public init(_ name: String, file: String = #file, line: UInt = #line, commit: @escaping CommitFunc = quick_it) {
     self.name = name
@@ -66,8 +66,12 @@ public final class Scenario: Preparable, Actionable {
     }
   }
 
-  fileprivate func commit(_ description: String, file: String, line: UInt, closure: @escaping () -> ()) {
+  private func commit(_ description: String, file: String, line: UInt, closure: @escaping () -> ()) {
     commitFunc(description, file, line, closure)
+  }
+
+  internal func addStep(_ description: String, file: String, line: UInt) {
+    stepDescriptions.append(description: description, file: file, line: line)
   }
 
 }
@@ -76,14 +80,6 @@ public typealias CommitFunc = (String, String, UInt, @escaping () -> ()) -> ()
 
 private let quick_it: CommitFunc = { description, file, line, closure in
   it(description, file: file, line: line, closure: closure)
-}
-
-extension Scenario: ScenarioBuilder {
-
-  func addStep(_ description: String, file: String, line: UInt) {
-    stepDescriptions.append(description: description, file: file, line: line)
-  }
-
 }
 
 private typealias StepMetadata = (description: String, file: String, line: UInt)

--- a/Scenarios/Scenario.swift
+++ b/Scenarios/Scenario.swift
@@ -66,7 +66,7 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
     }
   }
 
-  private func commit(_ description: String, file: String, line: UInt, closure: @escaping () -> ()) {
+  private func commit(_ description: String, file: String, line: UInt, closure: @escaping () -> Void) {
     commitFunc(description, file, line, closure)
   }
 
@@ -76,7 +76,7 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
 
 }
 
-public typealias CommitFunc = (String, String, UInt, @escaping () -> ()) -> ()
+public typealias CommitFunc = (String, String, UInt, @escaping () -> Void) -> Void
 
 private let quick_it: CommitFunc = { description, file, line, closure in
   it(description, file: file, line: line, closure: closure)

--- a/Scenarios/ScenarioBuilder.swift
+++ b/Scenarios/ScenarioBuilder.swift
@@ -1,7 +1,0 @@
-//  Copyright © 2015 Outware Mobile. All rights reserved.
-
-internal protocol ScenarioBuilder {
-
-  mutating func addStep(_ description: String, file: String, line: UInt)
-
-}

--- a/Scenarios/ScenarioBuilder.swift
+++ b/Scenarios/ScenarioBuilder.swift
@@ -1,5 +1,7 @@
 //  Copyright © 2015 Outware Mobile. All rights reserved.
 
 internal protocol ScenarioBuilder {
+
   mutating func addStep(_ description: String, file: String, line: UInt)
+
 }

--- a/Scenarios/ScenarioDescriptors.swift
+++ b/Scenarios/ScenarioDescriptors.swift
@@ -1,31 +1,5 @@
 //  Copyright © 2015 Outware Mobile. All rights reserved.
 
-// MARK: Roles
-
-public protocol Extendable {
-
-  func And(_ description: String, file: String, line: UInt) -> Self
-
-}
-
-public protocol Preparable {
-
-  func Given(_ description: String, file: String, line: UInt) -> Prepared
-
-}
-
-public protocol Actionable {
-
-  func When(_ description: String, file: String, line: UInt) -> Actioned
-
-}
-
-public protocol Assertable {
-
-  func Then(_ description: String, file: String, line: UInt) -> Asserted
-
-}
-
 // MARK: Types
 
 public final class Prepared: Assertable, Actionable, Extendable {
@@ -37,18 +11,18 @@ public final class Prepared: Assertable, Actionable, Extendable {
   }
 
   public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
-    builder.addStep(description, file: file, line: line)
+    builder.add(stepWithDescription: description, file: file, line: line)
     return self
   }
 
   public func When(_ description: String, file: String = #file, line: UInt = #line) -> Actioned {
-    builder.addStep(description, file: file, line: line)
+    builder.add(stepWithDescription: description, file: file, line: line)
     return Actioned(builder)
   }
 
   @discardableResult
   public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
-    builder.addStep(description, file: file, line: line)
+    builder.add(stepWithDescription: description, file: file, line: line)
     return Asserted(builder)
   }
 
@@ -63,13 +37,13 @@ public final class Actioned: Assertable, Extendable {
   }
 
   public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
-    builder.addStep(description, file: file, line: line)
+    builder.add(stepWithDescription: description, file: file, line: line)
     return self
   }
 
   @discardableResult
   public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
-    builder.addStep(description, file: file, line: line)
+    builder.add(stepWithDescription: description, file: file, line: line)
     return Asserted(builder)
   }
 
@@ -85,7 +59,7 @@ public final class Asserted: Extendable {
 
   @discardableResult
   public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
-    builder.addStep(description, file: file, line: line)
+    builder.add(stepWithDescription: description, file: file, line: line)
     return self
   }
 

--- a/Scenarios/ScenarioDescriptors.swift
+++ b/Scenarios/ScenarioDescriptors.swift
@@ -37,7 +37,8 @@ public final class Prepared: Assertable, Actionable, Extendable {
     return Actioned(builder)
   }
 
-  @discardableResult public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
+  @discardableResult
+  public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
     builder.addStep(description, file: file, line: line)
     return Asserted(builder)
   }
@@ -55,7 +56,8 @@ public final class Actioned: Assertable, Extendable {
     return self
   }
 
-  @discardableResult public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
+  @discardableResult
+  public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
     builder.addStep(description, file: file, line: line)
     return Asserted(builder)
   }
@@ -68,6 +70,7 @@ public final class Asserted: Extendable {
     self.builder = builder
   }
 
+  @discardableResult
   public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
     builder.addStep(description, file: file, line: line)
     return self

--- a/Scenarios/ScenarioDescriptors.swift
+++ b/Scenarios/ScenarioDescriptors.swift
@@ -3,24 +3,33 @@
 // MARK: Roles
 
 public protocol Extendable {
+
   func And(_ description: String, file: String, line: UInt) -> Self
+
 }
 
 public protocol Preparable {
+
   func Given(_ description: String, file: String, line: UInt) -> Prepared
+
 }
 
 public protocol Actionable {
+
   func When(_ description: String, file: String, line: UInt) -> Actioned
+
 }
 
 public protocol Assertable {
+
   func Then(_ description: String, file: String, line: UInt) -> Asserted
+
 }
 
 // MARK: Types
 
 public final class Prepared: Assertable, Actionable, Extendable {
+
   private var builder: ScenarioBuilder
 
   internal init(_ builder: ScenarioBuilder) {
@@ -42,9 +51,11 @@ public final class Prepared: Assertable, Actionable, Extendable {
     builder.addStep(description, file: file, line: line)
     return Asserted(builder)
   }
+
 }
 
 public final class Actioned: Assertable, Extendable {
+
   private var builder: ScenarioBuilder
 
   internal init(_ builder: ScenarioBuilder) {
@@ -61,9 +72,11 @@ public final class Actioned: Assertable, Extendable {
     builder.addStep(description, file: file, line: line)
     return Asserted(builder)
   }
+
 }
 
 public final class Asserted: Extendable {
+
   private var builder: ScenarioBuilder
 
   internal init(_ builder: ScenarioBuilder) {
@@ -75,4 +88,5 @@ public final class Asserted: Extendable {
     builder.addStep(description, file: file, line: line)
     return self
   }
+
 }

--- a/Scenarios/ScenarioDescriptors.swift
+++ b/Scenarios/ScenarioDescriptors.swift
@@ -21,7 +21,7 @@ public protocol Assertable {
 // MARK: Types
 
 public final class Prepared: Assertable, Actionable, Extendable {
-  fileprivate var builder: ScenarioBuilder
+  private var builder: ScenarioBuilder
 
   internal init(_ builder: ScenarioBuilder) {
     self.builder = builder
@@ -45,7 +45,7 @@ public final class Prepared: Assertable, Actionable, Extendable {
 }
 
 public final class Actioned: Assertable, Extendable {
-  fileprivate var builder: ScenarioBuilder
+  private var builder: ScenarioBuilder
 
   internal init(_ builder: ScenarioBuilder) {
     self.builder = builder
@@ -64,7 +64,7 @@ public final class Actioned: Assertable, Extendable {
 }
 
 public final class Asserted: Extendable {
-  fileprivate var builder: ScenarioBuilder
+  private var builder: ScenarioBuilder
 
   internal init(_ builder: ScenarioBuilder) {
     self.builder = builder

--- a/Scenarios/Step.swift
+++ b/Scenarios/Step.swift
@@ -1,11 +1,14 @@
 //  Copyright © 2015 Outware Mobile. All rights reserved.
 
 internal struct SourceLocation {
+
   var filePath: String
   var lineNumber: UInt
+
 }
 
 internal struct Step {
+
   let name: String
   let sourceLocation: SourceLocation
 
@@ -13,4 +16,5 @@ internal struct Step {
     self.name = name
     self.sourceLocation = SourceLocation(filePath: filePath, lineNumber: lineNumber)
   }
+
 }

--- a/Scenarios/StepArguments.swift
+++ b/Scenarios/StepArguments.swift
@@ -5,7 +5,7 @@ public struct StepArguments: Collection {
   public let startIndex: Int = 0
   public var endIndex: Int { return captures.endIndex }
 
-  fileprivate let captures: [String]
+  private let captures: [String]
 
   internal init(_ matchResult: MatchResult) {
     self.captures = matchResult.captures.flatMap { $0 }

--- a/Scenarios/StepDefinition.swift
+++ b/Scenarios/StepDefinition.swift
@@ -53,16 +53,16 @@ open class StepDefinition: QuickSpec {
 
   // MARK: Currently executing step
 
-  internal fileprivate(set) static var executingStep: Step?
+  internal private(set) static var executingStep: Step?
 
   // MARK: Registering step definitions
 
-  fileprivate func registerStep(withPattern pattern: String, definition: @escaping StepDefinitionFunc) {
+  private func registerStep(withPattern pattern: String, definition: @escaping StepDefinitionFunc) {
     let step: (Regex, StepDefinitionFunc) = (regex(forPattern: pattern), definition)
     type(of: self).stepDefinitions.append(step)
   }
 
-  fileprivate func regex(forPattern pattern: String) -> Regex {
+  private func regex(forPattern pattern: String) -> Regex {
     var pattern: String = pattern
     if !pattern.hasPrefix("^") { pattern.insert("^", at: pattern.startIndex) }
     if !pattern.hasSuffix("$") { pattern.insert("$", at: pattern.endIndex) }
@@ -73,7 +73,7 @@ open class StepDefinition: QuickSpec {
     }
   }
 
-  fileprivate static var stepDefinitions: [(Regex, StepDefinitionFunc)] = []
+  private static var stepDefinitions: [(Regex, StepDefinitionFunc)] = []
 
 }
 

--- a/Scenarios/StepDefinition.swift
+++ b/Scenarios/StepDefinition.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2015 Outware Mobile. All rights reserved.
 
-public typealias StepDefinitionFunc = (StepArguments) -> ()
-internal typealias StepActionFunc = () -> ()
+public typealias StepDefinitionFunc = (StepArguments) -> Void
+internal typealias StepActionFunc = () -> Void
 
 open class StepDefinition: QuickSpec {
 

--- a/Scenarios/StepDefinition.swift
+++ b/Scenarios/StepDefinition.swift
@@ -22,6 +22,7 @@ open class StepDefinition: QuickSpec {
   // MARK: Matching step definitions
 
   internal static func lookup(_ description: String, forStepInFile filePath: String, atLine lineNumber: UInt) -> () -> StepActionFunc? {
+
     let step = Step(name: description, inFile: filePath, atLine: lineNumber)
 
     return {
@@ -40,11 +41,12 @@ open class StepDefinition: QuickSpec {
         executingStep = nil
       }
     }
+
   }
 
   // MARK: Step definition hook
 
-  open func steps() {}
+  open func steps() { }
 
   open override func spec() {
     super.spec()

--- a/ScenariosTests/ScenarioSpec.swift
+++ b/ScenariosTests/ScenarioSpec.swift
@@ -37,11 +37,13 @@ final class ScenarioSpec: QuickSpec {
           expect(capturedName).to(equal("a new scenario"))
 
         }
+
       }
 
     }
 
   }
+
 }
 
 import Quick

--- a/ScenariosTests/ScenarioSpec.swift
+++ b/ScenariosTests/ScenarioSpec.swift
@@ -9,9 +9,11 @@ final class ScenarioSpec: QuickSpec {
         it("is the same as the name of the scenario") {
           var capturedName: String?
 
-          let _ = Scenario("a new scenario", commit: { (description: String, _, _, _) -> () in
+          let commitFunction: CommitFunc = { (description: String, _, _, _) -> Void in
             capturedName = description
-          })
+          }
+
+          _ = Scenario("a new scenario", commit: commitFunction)
 
           expect(capturedName).to(equal("a new scenario"))
         }
@@ -19,10 +21,11 @@ final class ScenarioSpec: QuickSpec {
         it("doesn't include any step names") {
           var capturedName: String?
 
-          Scenario("a new scenario",
-            commit: { (description: String, _, _, _) -> () in
-              capturedName = description
-            })
+          let commitFunction: CommitFunc = { (description: String, _, _, _) -> Void in
+            capturedName = description
+          }
+
+          _ = Scenario("a new scenario", commit: commitFunction)
             .Given("a single step")
 
           expect(capturedName).to(equal("a new scenario"))

--- a/ScenariosTests/ScenarioSpec.swift
+++ b/ScenariosTests/ScenarioSpec.swift
@@ -1,12 +1,15 @@
 //  Copyright © 2015 Outware Mobile. All rights reserved.
 
 final class ScenarioSpec: QuickSpec {
+
   override func spec() {
 
-    describe("Scenario") {
+    describe("A Scenario") {
 
-      describe("generated test name") {
+      describe("its generated test name") {
+
         it("is the same as the name of the scenario") {
+
           var capturedName: String?
 
           let commitFunction: CommitFunc = { (description: String, _, _, _) -> Void in
@@ -16,9 +19,11 @@ final class ScenarioSpec: QuickSpec {
           _ = Scenario("a new scenario", commit: commitFunction)
 
           expect(capturedName).to(equal("a new scenario"))
+
         }
 
         it("doesn't include any step names") {
+
           var capturedName: String?
 
           let commitFunction: CommitFunc = { (description: String, _, _, _) -> Void in
@@ -28,7 +33,9 @@ final class ScenarioSpec: QuickSpec {
           _ = Scenario("a new scenario", commit: commitFunction)
             .Given("a single step")
 
+          expect(capturedName).toNot(contain("a single step"))
           expect(capturedName).to(equal("a new scenario"))
+
         }
       }
 

--- a/ScenariosTests/StepArgumentsFeature.swift
+++ b/ScenariosTests/StepArgumentsFeature.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2015 Outware Mobile. All rights reserved.
 
 final class StepArgumentsFeature: Feature {
+
   override func scenarios() {
 
     Scenario("Single argument")
@@ -19,9 +20,11 @@ final class StepArgumentsFeature: Feature {
       .And("the third argument is baz")
 
   }
+
 }
 
 final class StepArgumentsSteps: StepDefinition {
+
   override func steps() {
 
     var capturedArgs: StepArguments!
@@ -61,6 +64,7 @@ final class StepArgumentsSteps: StepDefinition {
     }
 
   }
+
 }
 
 import Nimble


### PR DESCRIPTION
## Abstract:

Tidy up the code-base.

## Detail:

- Provide documentation for main scenario-building stages.
- Breathe clarity into some existing code (such as those in the test targets), by extracting declared closures into local variables for example.
- Audit scope declarations for code which was migrated to Swift 3 through the help of the migration tool.
- Style: Update style convention surrounding new-lines and spaces.