### PR TITLE
Fix test failures being reported in the wrong file

### DIFF
--- a/Scenarios/Components/Roles.swift
+++ b/Scenarios/Components/Roles.swift
@@ -25,7 +25,7 @@ public protocol Extendable {
   ///
   /// - returns: A scenario which captures all specifications in the previous scenario
   ///            as well as the new specification.
-  func And(_ description: String, file: String, line: UInt) -> Self
+  func And(_ description: String, file: StaticString, line: UInt) -> Self
 
 }
 
@@ -42,7 +42,7 @@ public protocol Preparable {
   /// - returns: A scenario which has had some preparation / arranging done.
   ///
   /// - seealso: Extendable
-  func Given(_ description: String, file: String, line: UInt) -> Prepared
+  func Given(_ description: String, file: StaticString, line: UInt) -> Prepared
 
 }
 
@@ -59,7 +59,7 @@ public protocol Actionable {
   /// - returns: A scenario which has had some action performed.
   ///
   /// - seealso: Extendable
-  func When(_ description: String, file: String, line: UInt) -> Actioned
+  func When(_ description: String, file: StaticString, line: UInt) -> Actioned
 
 }
 
@@ -75,7 +75,7 @@ public protocol Assertable {
   ///                    state be confirmed.
   ///
   /// - seealso: Extendable
-  func Then(_ description: String, file: String, line: UInt) -> Asserted
+  func Then(_ description: String, file: StaticString, line: UInt) -> Asserted
   
 }
 
@@ -92,6 +92,6 @@ internal protocol ScenarioBuilder {
   /// - parameters:
   ///     - description: A specification detailing the steps to be appended to the
   ///                    current state of the scenario.
-  mutating func add(stepWithDescription description: String, file: String, line: UInt)
+  mutating func add(stepWithDescription description: String, file: StaticString, line: UInt)
 
 }

--- a/Scenarios/Components/Types.swift
+++ b/Scenarios/Components/Types.swift
@@ -28,18 +28,18 @@ public final class Prepared: Assertable, Actionable, Extendable {
     self.builder = builder
   }
 
-  public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
+  public func And(_ description: String, file: StaticString = #file, line: UInt = #line) -> Self {
     builder.add(stepWithDescription: description, file: file, line: line)
     return self
   }
 
-  public func When(_ description: String, file: String = #file, line: UInt = #line) -> Actioned {
+  public func When(_ description: String, file: StaticString = #file, line: UInt = #line) -> Actioned {
     builder.add(stepWithDescription: description, file: file, line: line)
     return Actioned(builder)
   }
 
   @discardableResult
-  public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
+  public func Then(_ description: String, file: StaticString = #file, line: UInt = #line) -> Asserted {
     builder.add(stepWithDescription: description, file: file, line: line)
     return Asserted(builder)
   }
@@ -74,13 +74,13 @@ public final class Actioned: Assertable, Extendable {
     self.builder = builder
   }
 
-  public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
+  public func And(_ description: String, file: StaticString = #file, line: UInt = #line) -> Self {
     builder.add(stepWithDescription: description, file: file, line: line)
     return self
   }
 
   @discardableResult
-  public func Then(_ description: String, file: String = #file, line: UInt = #line) -> Asserted {
+  public func Then(_ description: String, file: StaticString = #file, line: UInt = #line) -> Asserted {
     builder.add(stepWithDescription: description, file: file, line: line)
     return Asserted(builder)
   }
@@ -123,7 +123,7 @@ public final class Asserted: Extendable {
   }
 
   @discardableResult
-  public func And(_ description: String, file: String = #file, line: UInt = #line) -> Self {
+  public func And(_ description: String, file: StaticString = #file, line: UInt = #line) -> Self {
     builder.add(stepWithDescription: description, file: file, line: line)
     return self
   }

--- a/Scenarios/Scenario.swift
+++ b/Scenarios/Scenario.swift
@@ -12,19 +12,19 @@
 public final class Scenario: Preparable, Actionable, ScenarioBuilder {
 
   private let name: String
-  private let file: String
+  private let file: StaticString
   private let line: UInt
   private let commitFunc: CommitFunc
   private var stepDescriptions: [StepMetadata] = []
 
-  public init(_ name: String, file: String = #file, line: UInt = #line, commit: @escaping CommitFunc) {
+  public init(_ name: String, file: StaticString = #file, line: UInt = #line, commit: @escaping CommitFunc) {
     self.name = name
     self.file = file
     self.line = line
     self.commitFunc = commit
   }
 
-  public convenience init(_ name: String, file: String = #file, line: UInt = #line) {
+  public convenience init(_ name: String, file: StaticString = #file, line: UInt = #line) {
     self.init(
       name,
       file: file,
@@ -33,12 +33,12 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
     )
   }
 
-  public func Given(_ description: String, file: String = #file, line: UInt = #line) -> Prepared {
+  public func Given(_ description: String, file: StaticString = #file, line: UInt = #line) -> Prepared {
     add(stepWithDescription: description, file: file, line: line)
     return Prepared(self)
   }
 
-  public func When(_ description: String, file: String = #file, line: UInt = #line) -> Actioned {
+  public func When(_ description: String, file: StaticString = #file, line: UInt = #line) -> Actioned {
     add(stepWithDescription: description, file: file, line: line)
     return Actioned(self)
   }
@@ -66,7 +66,7 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
 
       switch result {
       case let .missingStep(metadata):
-        XCTFail("couldn't match step description: '\(metadata.description)'", line: metadata.line)
+        XCTFail("couldn't match step description: '\(metadata.description)'", file: metadata.file, line: metadata.line)
       case let .matchedActions(actions):
         for action in actions {
           action()
@@ -75,23 +75,23 @@ public final class Scenario: Preparable, Actionable, ScenarioBuilder {
     }
   }
 
-  private func commit(_ description: String, file: String, line: UInt, closure: @escaping () -> Void) {
+  private func commit(_ description: String, file: StaticString, line: UInt, closure: @escaping () -> Void) {
     commitFunc(description, file, line, closure)
   }
 
-  internal func add(stepWithDescription description: String, file: String, line: UInt) {
+  internal func add(stepWithDescription description: String, file: StaticString, line: UInt) {
     stepDescriptions.append((description: description, file: file, line: line))
   }
 
 }
 
-public typealias CommitFunc = (String, String, UInt, @escaping () -> Void) -> Void
+public typealias CommitFunc = (String, StaticString, UInt, @escaping () -> Void) -> Void
 
 private let quick_it: CommitFunc = { description, file, line, closure in
-  it(description, file: file, line: line, closure: closure)
+  it(description, file: String(describing: file), line: line, closure: closure)
 }
 
-private typealias StepMetadata = (description: String, file: String, line: UInt)
+private typealias StepMetadata = (description: String, file: StaticString, line: UInt)
 
 private enum ResolvedSteps {
 

--- a/Scenarios/Step.swift
+++ b/Scenarios/Step.swift
@@ -12,9 +12,9 @@ internal struct Step {
   let name: String
   let sourceLocation: SourceLocation
 
-  init(name: String, inFile filePath: String, atLine lineNumber: UInt) {
+  init(name: String, inFile filePath: StaticString, atLine lineNumber: UInt) {
     self.name = name
-    self.sourceLocation = SourceLocation(filePath: filePath, lineNumber: lineNumber)
+    self.sourceLocation = SourceLocation(filePath: String(describing: filePath), lineNumber: lineNumber)
   }
 
 }

--- a/Scenarios/StepDefinition.swift
+++ b/Scenarios/StepDefinition.swift
@@ -24,7 +24,7 @@ open class StepDefinition: QuickSpec {
 
   // MARK: Matching step definitions
 
-  internal static func lookup(_ description: String, forStepInFile filePath: String, atLine lineNumber: UInt) -> () -> StepActionFunc? {
+  internal static func lookup(_ description: String, forStepInFile filePath: StaticString, atLine lineNumber: UInt) -> () -> StepActionFunc? {
 
     let step = Step(name: description, inFile: filePath, atLine: lineNumber)
 


### PR DESCRIPTION
Commit de3829b156e87fa5066eea51776dd689e5ba9d92 resolved a compiler error caused by passing a `String` into `XCTFail()`, which now requires its file parameter to be a `StaticString`. Unfortunately, removing the `file:` parameter means that test failures are no longer reported in the correct location in Xcode.

This resolves the issue by updating our API to accept `StaticString` instead of `String`, and transforming those static strings into `String` where necessary to bridge into Quick.